### PR TITLE
Use 7zip instead of tar

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,6 +9,6 @@ if !have_env && !isdir("/usr/local/gr") && !isdir(joinpath(homedir(),"gr"))
     info("Downloading pre-compiled GR $version binary")
     mkpath("downloads")
     download("http://gr-framework.org/downloads/$tarball", "downloads/$tarball")
-    run(`tar xzf downloads/$tarball`)
+    run(pipeline(`7z x -so downloads/$tarball`,`7z x -aoa -si -ttar -o"."`))
   end
 end


### PR DESCRIPTION
I did not have tar on my windows machine and build.jl failed on this line. This worked for me. 7zip is in the julia bin directory and i guess this hopefully work on all platforms.

----
I also suggest changing this if-statement 
`` if !isfile("downloads/$tarball") `` 

to check whether it has been successfully extracted instead. 