### PR TITLE
Enable use out of non-standard LOAD_PATH

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -185,7 +185,7 @@ function __init__()
         end
     end
     if grdir == None
-        grdir = joinpath(Pkg.dir(), "GR", "deps", "gr")
+        grdir = joinpath(dirname(@__FILE__), "..", "deps", "gr")
     end
     ENV["GRDIR"] = grdir
     ENV["GKS_FONTPATH"] = grdir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Base.Test
 tests = [ "ex", "griddata" ]
 
 for t in tests
-    tp = joinpath(Pkg.dir("GR"), "test", "$(t).jl")
+    tp = joinpath(dirname(@__FILE__), "$(t).jl")
     println("running $(tp) ...")
     inline("pdf")
     include(tp)


### PR DESCRIPTION
The use of `Pkg.dir` results in the standard path under .julia. If the package is installed elsewhere, such as in the preinstalled packages of JuliaBox (in /opt/julia_packages), the downloaded library is not found. Using `@__FILE__` solves that.