### PR TITLE
fixed conversion to latin1 - fixes #55

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -449,7 +449,7 @@ end
 
 function latin1(string)
   b = convert(Array{UInt8}, string)
-  s = zeros(UInt8, length(string))
+  s = zeros(UInt8, length(b))
   len = 0
   mask = 0
   for c in b


### PR DESCRIPTION
latin1 conversion now prints garbled text instead of exiting and throwing an error.
see https://github.com/jheinen/GR.jl/issues/55
