### PR TITLE
Use rpath and QML-supplied path for Qt5

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -58,17 +58,13 @@ if !have_dir
     app = joinpath("gr", "Applications", "GKSTerm.app")
     run(`/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f $app`)
     try
-      @eval import Homebrew
-      if Pkg.installed("Homebrew") != nothing
-        qt = Homebrew.prefix("qt")
+      @eval import QML
+      if Pkg.installed("QML") != nothing
+        qt = QML.qt_prefix_path()
         path = joinpath(qt, "Frameworks")
         if isdir(path)
-          for d in ("QtCore.framework", "QtGui.framework", "QtWidgets.framework")
-            target = joinpath(path, d)
-            link = joinpath(pwd(), "gr", "lib", d)
-            rm(link, force=true)
-            symlink(target, link)
-          end
+          qt5plugin = joinpath(pwd(), "gr", "lib", "qt5plugin.so")
+          run(`install_name_tool -add_rpath $path $qt5plugin`)
           println("Using Qt ", splitdir(qt)[end], " at ", qt)
         end
       end


### PR DESCRIPTION
Sorry for the delay, but to continue https://github.com/barche/QML.jl/issues/23#issuecomment-302429245 this uses QML to find out what Qt5 is used and adds it to the qt5plugin.so rpath. The advantage is that this works also when a non-homebrew Qt is used or a Qt from a non-Julia homebrew (my case) is used.

CC @scls19fr