### PR TITLE
Fixes the histogram bug where first and last bin are not filled properly

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -1049,19 +1049,17 @@ function stem(args...; kv...)
 end
 
 function hist(x, nbins::Integer=0)
-    xmin, xmax = minimum(x), maximum(x)
     if nbins <= 1
         nbins = round(Int, 3.3 * log10(length(x))) + 1
     end
 
+    xmin, xmax = extrema(x) 
     edges = linspace(xmin, xmax, nbins + 1)
     counts = zeros(nbins)
-
-    for v in x
-        idx = round(Int, (v - xmin) / (xmax - xmin) * (nbins - 1)) + 1
-        counts[idx] += 1
+    buckets = Int[max(2, min(searchsortedfirst(edges, xᵢ), length(edges)))-1 for xᵢ in x]
+    for b in buckets
+        counts[b] += 1
     end
-
     collect(edges), counts
 end
 


### PR DESCRIPTION
Easily testable with 

```julia
GR.histogram(rand(5000), nbins=10)
```

Before:
![screen shot 2017-06-07 at 23 03 27](https://user-images.githubusercontent.com/1722/26901314-a4727870-4bd5-11e7-9b81-002ecdce7e5e.png)

After:

![screen shot 2017-06-07 at 23 03 47](https://user-images.githubusercontent.com/1722/26901316-ac4f3d4e-4bd5-11e7-8352-c0603415b571.png)

