### PR TITLE
Crude fix for UTF-8 -> Latin1 conversion

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -456,20 +456,15 @@ function polymarker(x, y)
 end
 
 function latin1(string)
-  b = convert(Array{UInt8}, string)
   s = zeros(UInt8, length(string))
   len = 0
-  mask = 0
-  for c in b
-    if c != 0xc2 && c != 0xc3
-      len += 1
-      s[len] = c | mask
-    end
-    if c == 0xc3
-      mask = 0x40
-    else
-      mask = 0
-    end
+  for c in string
+    len += 1
+    s[len] = try
+        convert(UInt8, c)
+      catch
+        0x3f
+      end
   end
   return s
 end


### PR DESCRIPTION
Currently trying to use GR with labels like "α" fails miserably with out-of bounds array access.  This fix properly converts all latin1 characters (accented latin letters) to latin1, and replaces everything else (like Greek letter) with "?"

Test case:

using GR
x=1:0.1:6
legend("très compliqué πολύ περίπλοκο")
plot(x,sin.(x))
