### PR TITLE
fix deprecation warning for mlterm

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3126,7 +3126,7 @@ function show()
         return nothing
     elseif mime_type == "mlterm"
         content = read(file_path)
-        write(content)
+        write(STDOUT, content)
         rm(file_path)
         return nothing
     elseif mime_type == "atom"


### PR DESCRIPTION
The single-argument form of `write` has been deprecated in Julia v0.6.