### PR TITLE
fix unintended modification of :subplot in set_viewport

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -102,7 +102,7 @@ function set_viewport(kind, subplot)
         end
     end
     viewport = zeros(4)
-    vp = float(subplot)
+    vp = copy(float(subplot))
     if w > h
         ratio = float(h) / w
         msize = mwidth * w / width


### PR DESCRIPTION
float(subplot) return subplot itself if it is already float type.
Subsequent modification to vp therefore affects plt[:subplot].