### PR TITLE
Fix bug in normalization

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -737,7 +737,12 @@ function plot_img(I)
         width, height, data = GR.readimage(I)
     else
         width, height = size(I)
-        data = (float(I) .- minimum(I)) ./ (maximum(I) .- minimum(I))
+        minI = minimum(I)
+        maxI = maximum(I)
+        data = float(I) .- minI
+        if minI != maxI
+            data ./= maxI .- minI
+        end
         data = Int32[round(Int32, 1000 + _i * 255) for _i in data]
     end
 


### PR DESCRIPTION
Hi, thank you for your great work! I found this package when I was searching for a lightning fast plotting package for real-time image monitoring. GR works like a charm.

Today I came across an error, I would like to fix this. In short, `imshow()` function raises error with an flat image, `minimum(I) == maximum(I)`, because of zero-division in [plot_img(I)](https://github.com/jheinen/GR.jl/blob/366037d2cd7475def2f15065ba541eebffee0496/src/jlgr.jl#L740). For example, probably you can reproduce by doing this:

```julia
using GR
imshow(zeros(3, 3))
```

It raises Inexact Error.

I thought of three cases:
  1. Normal image (`minimum(I) < maximum(I)`)
  1. Flat image (`minimum(I) == maximum(I) > 0`)
  1. Zero-filled image (`minimum(I) == maximum(I) == 0`)

The first one will be plotted as same as before. The last one will be plotted as a "black" (depends on colormap, but...) image, and it is probably reasonable. The problem is I am not very sure how the second case should be. This pr draws it as same as the third case.