### PR TITLE
Check that `Main.Atom` and `Main.IJulia` are modules

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -209,8 +209,8 @@ else
   const libGR3 = "libGR3.so"
 end
 
-isijulia() = isdefined(Main, :IJulia) && isdefined(Main.IJulia, :clear_output)
-isatom() = isdefined(Main, :Atom) && Main.Atom.isconnected()
+isijulia() = isdefined(Main, :IJulia) && Main.IJulia isa Module && isdefined(Main.IJulia, :clear_output)
+isatom() = isdefined(Main, :Atom) && Main.Atom isa Module && Main.Atom.isconnected()
 
 function __init__()
     global display_name, mime_type, file_path, send_c, recv_c


### PR DESCRIPTION
I have a module that exports a struct `Atom` to represent actual atoms.  This PR checks to ensure that `Main.Atom` actually is a module, and not an atom, before assuming it's an editor. :smile: 

Also added a similar check for `IJulia` on the line above.