### PR TITLE
add methods to `create_context` and define `redraw`

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -168,6 +168,7 @@ export
   wireframe,
   plot3,
   scatter3,
+  redraw,
   title,
   xlabel,
   ylabel,
@@ -3108,6 +3109,7 @@ volume(V; kwargs...) = jlgr.volume(V; kwargs...)
 plot3(args...; kwargs...) = jlgr.plot3(args...; kwargs...)
 scatter3(args...; kwargs...) = jlgr.scatter3(args...; kwargs...)
 title(s) = jlgr.title(s)
+redraw(; kwargs...) = jlgr.redraw(; kwargs...)
 xlabel(s) = jlgr.xlabel(s)
 ylabel(s) = jlgr.ylabel(s)
 legend(args...; kwargs...) = jlgr.legend(args...; kwargs...)

--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -647,8 +647,12 @@ function to_rgba(value, cmap)
     round(UInt32, g * 255) << 8  + round(UInt32, r * 255)
 end
 
-function create_context(kind, dict)
+function create_context(kind::Symbol, dict=plt.kvs)
     plt.kvs[:kind] = kind
+    create_context(dict)
+end
+
+function create_context(dict::AbstractDict)
     plt.obj = copy(plt.kvs)
     for (k, v) in dict
         if ! (k in kw_args)
@@ -1998,6 +2002,32 @@ function scatter3(args...; kv...)
 
     plt.args = plot_args(args, fmt=:xyzc)
 
+    plot_data()
+end
+
+"""
+Redraw current plot
+
+This can be used to update the current plot, after setting some
+attributes like the title, axes labels, legend, etc.
+
+**Usage examples:**
+
+.. code-block:: julia-repl
+
+    julia> # Create example data
+    julia> x = LinRange(-2, 2, 40)
+    julia> y = 2 .* x .+ 4
+    julia> # Add title and labels
+    julia> title("Example plot")
+    julia> xlabel("x")
+    julia> ylabel("y")
+    julia> # Redraw the plot with the new attributes
+    julia> redraw()
+
+"""
+function redraw(; kv...)
+    create_context(Dict(kv))
     plot_data()
 end
 


### PR DESCRIPTION
This allows to use a more "matlab-like" work flow, such that you can first plot the data, and then set the plot title, legend, axes labels, limits, etc. (now you must normally do it the other way round).

The plot still has to be manually redrawn, by calling the proposed function `redraw` (feel free to rename it if the name is not good).

`create_context` has new methods to allow create a context without telling explicitly the kind (just take the one that already exists).

The attributes that can be passed as keyword arguments to `redraw` are not fixed in the figure (they are not reminded if `redraw` is called later on; they are just saved in the global `ctx`). But that's consistent with the current logic, I think.
