### PR TITLE
Custom tick labels

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -176,6 +176,8 @@ export
   xticks,
   yticks,
   zticks,
+  xticklabels,
+  yticklabels,
   legend,
   xlim,
   ylim,
@@ -3170,6 +3172,8 @@ drawgrid(flag) = jlgr.drawgrid(flag)
 xticks(args...) = jlgr.xticks(args...)
 yticks(args...) = jlgr.yticks(args...)
 zticks(args...) = jlgr.zticks(args...)
+xticklabels(s) = jlgr.xticklabels(s)
+yticklabels(s) = jlgr.yticklabels(s)
 legend(args...; kwargs...) = jlgr.legend(args...; kwargs...)
 xlim(a) = jlgr.xlim(a)
 ylim(a) = jlgr.ylim(a)

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -81,6 +81,7 @@ export
   textext,
   inqtextext,
   axes2d, # to avoid WARNING: both GR and Base export "axes"
+  axeslbl,
   grid,
   grid3d,
   verrorbars,

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -1817,6 +1817,56 @@ end
 axes(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real) = axes2d(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real)
 
 """
+    function axeslbl(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real, fpx::Function, fpy::Function)
+
+Draw X and Y coordinate axes with linearly and/or logarithmically spaced tick marks.
+
+Tick marks are positioned along each axis so that major tick marks fall on the
+axes origin (whether visible or not). Major tick marks are labeled with the
+corresponding data values. Axes are drawn according to the scale of the window.
+Axes and tick marks are drawn using solid lines; line color and width can be
+modified using the `setlinetype` and `setlinewidth` functions.
+Axes are drawn according to the linear or logarithmic transformation established
+by the `setscale` function.
+
+**Parameters:**
+
+`x_tick`, `y_tick` :
+    The interval between minor tick marks on each axis.
+`x_org`, `y_org` :
+    The world coordinates of the origin (point of intersection) of the X
+    and Y axes.
+`major_x`, `major_y` :
+    Unitless integer values specifying the number of minor tick intervals
+    between major tick marks. Values of 0 or 1 imply no minor ticks.
+    Negative values specify no labels will be drawn for the associated axis.
+`tick_size` :
+    The length of minor tick marks specified in a normalized device
+    coordinate unit. Major tick marks are twice as long as minor tick marks.
+    A negative value reverses the tick marks on the axes from inward facing
+    to outward facing (or vice versa).
+`fx`, `fy` :
+    Functions that returns a label for a given tick on the X or Y axis.
+    Those functions should have the following arguments:
+`x`, `y` :
+    Normalized device coordinates of the label in X and Y directions.
+`svalue` :
+    Internal string representation of the text drawn at `(x,y).
+`value` :
+    Floating point representation of the label drawn at `(x,y)`.
+
+"""
+function axeslbl(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real, fx::Function, fy::Function)
+  fx_c = @cfunction($fx, Nothing, (Float64, Float64, Cstring, Float64))
+  fy_c = @cfunction($fy, Nothing, (Float64, Float64, Cstring, Float64))
+  ccall( (:gr_axeslbl, libGR),
+        Nothing,
+        (Float64, Float64, Float64, Float64, Int32, Int32, Float64, Ptr{Nothing}, Ptr{Nothing}),
+        x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size, fx_c, fy_c)
+end
+
+
+"""
     grid(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int)
 
 Draw a linear and/or logarithmic grid.

--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -434,7 +434,15 @@ function draw_axes(kind, pass=1)
         else
             drawgrid && GR.grid(xtick, ytick, 0, 0, majorx, majory)
         end
-        GR.axes(xtick, ytick, xorg[1], yorg[1], majorx, majory, ticksize)
+        if haskey(plt.kvs, :xticklabels) || haskey(plt.kvs, :yticklabels)
+            xtfun = get(plt.kvs, :xticklabels, identity)
+            @eval fx = (x, y, svalue, value) -> GR.textext(x, y, string($xtfun(value)))
+            ytfun = get(plt.kvs, :yticklabels, identity)
+            @eval fy = (x, y, svalue, value) -> GR.textext(x, y, string($ytfun(value)))
+            GR.axeslbl(xtick, ytick, xorg[1], yorg[1], majorx, majory, ticksize, fx, fy)
+        else
+            GR.axes(xtick, ytick, xorg[1], yorg[1], majorx, majory, ticksize)
+        end
         GR.axes(xtick, ytick, xorg[2], yorg[2], -majorx, -majory, -ticksize)
     end
 

--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -831,8 +831,10 @@ Set the flag to draw a grid in the plot axes.
 """
 drawgrid(flag) = (plt.kvs[:grid] = flag)
 
-"""
-Set the intervals of the ticks for the x axis.
+const doc_ticks = """
+Set the intervals of the ticks for the X, Y or Z axis.
+
+Use the function `xticks`, `yticks` or `zticks` for the corresponding axis.
 
 :param minor: the interval between minor ticks.
 :param major: (optional) the number of minor ticks between major ticks.
@@ -841,46 +843,15 @@ Set the intervals of the ticks for the x axis.
 
 .. code-block:: julia
 
-    julia> # Minor ticks every 0.2 units
+    julia> # Minor ticks every 0.2 units in the X axis
     julia> xticks(0.2)
-    julia> # Major ticks every 1 unit (5 minor ticks)
-    julia> xticks(0.2, 5)
-"""
-xticks(minor, major::Int=1) = (plt.kvs[:xticks] = (minor, major))
-
-"""
-Set the intervals of the ticks for the y axis.
-
-:param minor: the interval between minor ticks.
-:param major: (optional) the number of minor ticks between major ticks.
-
-**Usage examples:**
-
-.. code-block:: julia
-
-    julia> # Minor ticks every 0.2 units
-    julia> yticks(0.2)
-    julia> # Major ticks every 1 unit (5 minor ticks)
+    julia> # Major ticks every 1 unit (5 minor ticks) in the Y axis
     julia> yticks(0.2, 5)
 """
-yticks(minor, major::Int=1) = (plt.kvs[:yticks] = (minor, major))
 
-"""
-Set the intervals of the ticks for the z axis.
-
-:param minor: the interval between minor ticks.
-:param major: (optional) the number of minor ticks between major ticks.
-
-**Usage examples:**
-
-.. code-block:: julia
-
-    julia> # Minor ticks every 0.2 units
-    julia> zticks(0.2)
-    julia> # Major ticks every 1 unit (5 minor ticks)
-    julia> zticks(0.2, 5)
-"""
-zticks(minor, major::Int=1) = (plt.kvs[:zticks] = (minor, major))
+@doc doc_ticks xticks(minor, major::Int=1) = (plt.kvs[:xticks] = (minor, major))
+@doc doc_ticks yticks(minor, major::Int=1) = (plt.kvs[:yticks] = (minor, major))
+@doc doc_ticks zticks(minor, major::Int=1) = (plt.kvs[:zticks] = (minor, major))
 
 const doc_ticklabels = """
 Customize the string of the X and Y axes tick labels.


### PR DESCRIPTION
New `axeslbl` function in `GR`;  `xticklabels` and `yticklabels` in `jlgr`.

For instance:
```julia
# Set minor ticks every π/8, major ticks every π/2 (minor ticks times 4)
xticks(π/8,4)
# Pretty format for the tick labels
xticklabels((x)->Base.Printf.@sprintf("%0.1f\\pi",x/π))
plot(-2π:0.01:2π, sin.(-2π:0.01:2π))
```

![grsinplot](https://user-images.githubusercontent.com/10651028/58356954-45e09700-7e79-11e9-8e10-e1f590506278.png)

`xticklabels`, `yticklabels` also accept a sequence of strings to associate them to integer values (1, 2, 3...). It may come in handy for future functionalities, like bar plots.