### PR TITLE
transpose x-y axes in of contours, surfaces and images

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -1248,6 +1248,8 @@ function plot_data(flag=true)
             if length(x) == length(y) == length(z)
                 x, y, z = GR.gridit(x, y, z, 200, 200)
                 zmin, zmax = get(plt.kvs, :zlim, (_min(z), _max(z)))
+            else
+                z = z'
             end
             GR.setspace(zmin, zmax, 0, 90)
             levels = get(plt.kvs, :levels, 0)
@@ -1265,6 +1267,8 @@ function plot_data(flag=true)
             if length(x) == length(y) == length(z)
                 x, y, z = GR.gridit(x, y, z, 200, 200)
                 zmin, zmax = get(plt.kvs, :zlim, (_min(z), _max(z)))
+            else
+                z = z'
             end
             GR.setspace(zmin, zmax, 0, 90)
             levels = get(plt.kvs, :levels, 0)
@@ -1300,6 +1304,8 @@ function plot_data(flag=true)
         elseif kind == :wireframe
             if length(x) == length(y) == length(z)
                 x, y, z = GR.gridit(x, y, z, 50, 50)
+            else
+                z = z'
             end
             GR.setfillcolorind(0)
             GR.surface(x, y, z, GR.OPTION_FILLED_MESH)
@@ -1307,6 +1313,8 @@ function plot_data(flag=true)
         elseif kind == :surface
             if length(x) == length(y) == length(z)
                 x, y, z = GR.gridit(x, y, z, 200, 200)
+            else
+                z = z'
             end
             if get(plt.kvs, :accelerate, true)
                 gr3.clear()
@@ -1877,8 +1885,8 @@ points or a two-dimensional array as a contour plot. It can receive one
 or more of the following:
 
 - x values, y values and z values, or
-- N x values, M y values and z values on a NxM grid, or
-- N x values, M y values and a callable to determine z values
+- M x values, N y values and z values on a NxM grid, or
+- M x values, N y values and a callable to determine z values
 
 If a series of points is passed to this function, their values will be
 interpolated on a grid. For grid points outside the convex hull of the
@@ -1922,8 +1930,8 @@ points or a two-dimensional array as a filled contour plot. It can
 receive one or more of the following:
 
 - x values, y values and z values, or
-- N x values, M y values and z values on a NxM grid, or
-- N x values, M y values and a callable to determine z values
+- M x values, N y values and z values on a NxM grid, or
+- M x values, N y values and a callable to determine z values
 
 If a series of points is passed to this function, their values will be
 interpolated on a grid. For grid points outside the convex hull of the
@@ -2070,8 +2078,8 @@ points or a two-dimensional array as a wireframe plot. It can receive one
 or more of the following:
 
 - x values, y values and z values, or
-- N x values, M y values and z values on a NxM grid, or
-- N x values, M y values and a callable to determine z values
+- M x values, N y values and z values on a NxM grid, or
+- M x values, N y values and a callable to determine z values
 
 If a series of points is passed to this function, their values will be
 interpolated on a grid. For grid points outside the convex hull of the
@@ -2115,8 +2123,8 @@ points or a two-dimensional array as a surface plot. It can receive one or
 more of the following:
 
 - x values, y values and z values, or
-- N x values, M y values and z values on a NxM grid, or
-- N x values, M y values and a callable to determine z values
+- M x values, N y values and z values on a NxM grid, or
+- M x values, N y values and a callable to determine z values
 
 If a series of points is passed to this function, their values will be
 interpolated on a grid. For grid points outside the convex hull of the

--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -1917,6 +1917,11 @@ provided points, a value of 0 will be used.
 function contour(args...; kv...)
     create_context(:contour, Dict(kv))
 
+    if length(args) == 1 && typeof(args[1]) <: AbstractMatrix
+        ny, nx = size(args[1])
+        args = (collect(1:nx), collect(1:ny), args...)
+    end
+    
     plt.args = plot_args(args, fmt=:xyzc)
 
     plot_data()
@@ -1962,6 +1967,11 @@ provided points, a value of 0 will be used.
 function contourf(args...; kv...)
     create_context(:contourf, Dict(kv))
 
+    if length(args) == 1 && typeof(args[1]) <: AbstractMatrix
+        ny, nx = size(args[1])
+        args = (collect(1:nx), collect(1:ny), args...)
+    end
+    
     plt.args = plot_args(args, fmt=:xyzc)
 
     plot_data()
@@ -2110,6 +2120,11 @@ provided points, a value of 0 will be used.
 function wireframe(args...; kv...)
     create_context(:wireframe, Dict(kv))
 
+    if length(args) == 1 && typeof(args[1]) <: AbstractMatrix
+        ny, nx = size(args[1])
+        args = (collect(1:nx), collect(1:ny), args...)
+    end
+    
     plt.args = plot_args(args, fmt=:xyzc)
 
     plot_data()
@@ -2155,6 +2170,11 @@ provided points, a value of 0 will be used.
 function surface(args...; kv...)
     create_context(:surface, Dict(kv))
 
+    if length(args) == 1 && typeof(args[1]) <: AbstractMatrix
+        ny, nx = size(args[1])
+        args = (collect(1:nx), collect(1:ny), args...)
+    end
+    
     plt.args = plot_args(args, fmt=:xyzc)
 
     plot_data()


### PR DESCRIPTION
* Transpose matrix inputs of `contour`, `contourf`, `surface` and `wireframe` (X axis represented in columns, Y in rows). This makes the interface consistent with [matplotlib](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.contour.html), [Plots.jl](http://docs.juliaplots.org/latest/examples/gr/#contours), and also with the interface of `heatmap` in GR (#241).
* Transpose matrix input of `imshow`, such that the displayed image looks like the input (#241).
* Fix bug with filename input of `imshow` (#239).