### PR TITLE
add offline

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,6 +3339,15 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
+function offline()
+    global mime_type, file_path
+    mime_type = None
+    file_path = None
+    delete!(ENV, "GKS_WSTYPE")
+    delete!(ENV, "GKS_FILEPATH")
+    emergencyclosegks()
+end
+
 function show()
     global mime_type, file_path, figure_count
 

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,10 +3339,11 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
-function offline()
-    global mime_type, file_path
+function reset()
+    global mime_type, file_path, figure_count
     mime_type = None
     file_path = None
+    figure_count = None
     delete!(ENV, "GKS_WSTYPE")
     delete!(ENV, "GKS_FILEPATH")
     emergencyclosegks()


### PR DESCRIPTION
This solves a situation like the following one:

``` julia
using GR
# I want to make this movie:
GR.inline("mov")
for x = 0:90
    plot((0:360) .+ x, sind)
end
# Now I want to make "normal" plots again.
GR.inline()
plot((0:360), sind)
```

This works nicely in Atom or in a Jupyter notebook, because `GR.inline()` by default sets the global `mime_type` to `"svg"`, which is what those environments use to show plots.

But in the REPL the default `mime_type` is `GR.None` (i.e. `Union{}`). So `GR.inline()` does close the video file (this is fine), but does not get back to the default context.

I thought on two possible workarounds:
1. Modify `GR.inline` such that the default MIME type is not always `"svg"`, but depends on the environment.
2. Add a function that resets `mime_type` to `GR.None`, which is the general default, as in the REPL. (Thus, in the previous example you may call `GR.offline()` after creating the movie, to get back to the default context in the REPL.)

I think that the first solution would be nicer, but more breaking, so I'm proposing the second one, which does not change the current behavior.

I called the new function `offline` because when you query `GR.isinline()` it returns false if `mime_type == GR.None`. But it might be changed.