### PR TITLE
inline(None)

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,13 +3339,17 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
-function offline()
-    global mime_type, file_path
-    mime_type = None
-    file_path = None
-    delete!(ENV, "GKS_WSTYPE")
-    delete!(ENV, "GKS_FILEPATH")
-    emergencyclosegks()
+function inline(::typeof(None))
+    global mime_type, file_path, figure_count
+    if mime_type != None
+        mime_type = None
+        file_path = None
+        figure_count = None
+        delete!(ENV, "GKS_WSTYPE")
+        delete!(ENV, "GKS_FILEPATH")
+        emergencyclosegks()
+    end
+    return ""
 end
 
 function show()

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,6 +3339,15 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
+function offline()
+    global mime_type, file_path
+    mime_type = None
+    file_path = None
+    delete!(ENV, "GKS_WSTYPE")
+    delete!(ENV, "GKS_FILEPATH")
+    emergencyclosegks()
+end
+
 function show()
     global mime_type, file_path, figure_count
 


### PR DESCRIPTION
A (non-breaking) alternative to #249. Instead of a new function like `offline`, this creates a new method of `inline` that is called when it receives the argument `None`. With this, to plot "normal" plots again in the REPL you should call `GR.inline(GR.None)`.

This does  not break the current interface, because currently `GR.inline(GR.None)` throws an error.