### PR TITLE
conditional behavior of `inline()`

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,13 +3339,17 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
-function offline()
-    global mime_type, file_path
-    mime_type = None
-    file_path = None
-    delete!(ENV, "GKS_WSTYPE")
-    delete!(ENV, "GKS_FILEPATH")
-    emergencyclosegks()
+function inline(::typeof(None))
+    global mime_type, file_path, figure_count
+    if mime_type != None
+        mime_type = None
+        file_path = None
+        figure_count = None
+        delete!(ENV, "GKS_WSTYPE")
+        delete!(ENV, "GKS_FILEPATH")
+        emergencyclosegks()
+    end
+    return ""
 end
 
 function show()

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3339,6 +3339,15 @@ function inline(mime="svg", scroll=true)
     mime_type
 end
 
+function offline()
+    global mime_type, file_path
+    mime_type = None
+    file_path = None
+    delete!(ENV, "GKS_WSTYPE")
+    delete!(ENV, "GKS_FILEPATH")
+    emergencyclosegks()
+end
+
 function show()
     global mime_type, file_path, figure_count
 

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -290,6 +290,9 @@ function __init__()
             encoding = "utf8"
         end
     end
+    if mime_type != None
+        ENV["GRMIME"] = mime_type
+    end
 end
 
 function initgr()
@@ -3312,10 +3315,12 @@ function displayname()
     return display_name
 end
 
-function inline(mime="svg", scroll=true)
+function inline(mime, scroll=true)
     global mime_type, file_path, figure_count, send_c, recv_c
     if mime_type != mime
-        if mime == "iterm"
+        if mime == ""
+            return inline(None) 
+        elseif mime == "iterm"
             file_path = tempname() * ".pdf"
             ENV["GKS_WSTYPE"] = "pdf"
         elseif mime == "mlterm"
@@ -3351,6 +3356,8 @@ function inline(::typeof(None))
     end
     return ""
 end
+
+inline() = inline( get(ENV, "GRMIME", "") )
 
 function show()
     global mime_type, file_path, figure_count


### PR DESCRIPTION
This is the breaking alternative to the problem commented in #249: `GR.inline()` - with no arguments - will make the MIME type return to its original value, i.e. `"svg"` in Atom or Jupyter, and `None` in the REPL and other environments.

In order to achieve this I have added the key `"GRMIME"` to `ENV`. If this environment variable is set to an empty string, the behavior will be as if you were in the REPL, i.e. the MIME type will be `None`.