### PR TITLE
fix draw_polar_axes

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -515,12 +515,11 @@ function draw_polar_axes()
         end
     end
     for alpha in 0:45:315
-        a = alpha + 90
-        sinf = sin(a * π / 180)
-        cosf = cos(a * π / 180)
-        GR.polyline([sinf, 0], [cosf, 0])
+        sinf = sin(alpha * π / 180)
+        cosf = cos(alpha * π / 180)
+        GR.polyline([cosf, 0], [sinf, 0])
         GR.settextalign(GR.TEXT_HALIGN_CENTER, GR.TEXT_VALIGN_HALF)
-        x, y = GR.wctondc(1.1 * sinf, 1.1 * cosf)
+        x, y = GR.wctondc(1.1 * cosf, 1.1 * sinf)
         GR.textext(x, y, string(alpha, "^o"))
     end
     GR.restorestate()


### PR DESCRIPTION
In this example:

```julia
angles = LinRange(0, 2pi, 40)
radii = LinRange(0, 2, 40)
polar(angles, radii)
```

In master the angle labels are clockwise, although the plotted angles are counter-clockwise:

![polarbefore](https://user-images.githubusercontent.com/10651028/66238669-4e36c180-e6f8-11e9-88ad-d4a5cc1139c1.png)

This PR draws the correct labels:

![polarafter](https://user-images.githubusercontent.com/10651028/66239535-66a7db80-e6fa-11e9-86b1-c8b53a066ea1.png)


