### PR TITLE
Tag videos with the correct mime types

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -3375,7 +3375,8 @@ function show()
         rm(file_path)
         return content
     elseif mime_type in ("mov", "mp4", "webm")
-        content = HTML(string("""<video autoplay controls><source type="video/mp4" src="data:video/mp4;base64,""", Base64.base64encode(open(read,file_path)),""""></video>"""))
+        mimespec = mime_type == "mov" ? "movie/quicktime" : "video/$mime_type"
+        content = HTML(string("""<video autoplay controls><source type="$mimespec" src="data:$mimespec;base64,""", Base64.base64encode(open(read,file_path)),""""></video>"""))
         rm(file_path)
         return content
     elseif mime_type == "iterm"


### PR DESCRIPTION
If `mime_type` is "mov", "mp4" or "webm", the HTML generated by `GR.show` tagged the video object as "video/mp4" in all cases.

This leaves that tag only if `mime_type` is "mp4". For "webm" it changes to "video/webm", and for "mov" to "video/quicktime".