### PR TITLE
Added linespec support to plot3

### DIFF
--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -1333,7 +1333,9 @@ function plot_data(flag=true)
             plt.kvs[:zrange] = dmin, dmax
             colorbar(0.05)
         elseif kind == :plot3
-            GR.polyline3d(x, y, z)
+            mask = GR.uselinespec(spec)
+            hasline(mask) && GR.polyline3d(x, y, z)
+            hasmarker(mask) && GR.polymarker3d(x, y, z)
             draw_axes(kind, 2)
         elseif kind == :scatter3
             GR.setmarkertype(GR.MARKERTYPE_SOLID_CIRCLE)


### PR DESCRIPTION
Hello.

I try to add support for spec in plot3.
Just as the same as `plot`.
But the code below does not work.

```
GR.plot3(x,y,z,"d")
```

Thanks.