### PR TITLE
modified gr_copyseg to gr_copysegws

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -1847,8 +1847,8 @@ function createseg(segment::Int)
         segment)
 end
 
-function copyseg(segment::Int)
-  ccall( (:gr_copyseg, libGR),
+function copysegws(segment::Int)
+  ccall( (:gr_copysegws, libGR),
         Nothing,
         (Int32, ),
         segment)


### PR DESCRIPTION
I found a small typo.
`gr_copyseg` is not function but struct (and this is not exported).