### PR TITLE
Small build tweak to enable correct os detection for PopOS

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -82,7 +82,7 @@ if grdir == Nothing
         elseif isfile("/etc/os-release")
             id = get_os_release("ID")
             id_like = get_os_release("ID_LIKE")
-            if id == "ubuntu" || id_like == "ubuntu"
+            if id == "ubuntu" || id_like == "ubuntu" || id_like == "ubuntu debian"
                 os = "Ubuntu"
             elseif id == "debian" || id_like == "debian"
                 os = "Debian"


### PR DESCRIPTION
On trying out this package I hit this issue, but I previously installed the needed external dependencies in the documentation.

```
julia> histogram(randn(1000))
/home/jakebolewski/.julia/packages/GR/cRdXQ/src/../deps/gr/bin/gksqt: error while loading shared libraries: libQtGui.so.4: cannot open shared object file: No such file or directory
```

After some confusion, I realized that it was downloading the generic Linux build that seems to default to linking to older qt4 libraries:

```
shell> ldd /home/jakebolewski/.julia/packages/GR/cRdXQ/src/../deps/gr/bin/gksqt
	linux-vdso.so.1 (0x00007ffccace2000)
	libQtGui.so.4 => not found
	libQtNetwork.so.4 => not found
	libQtCore.so.4 => not found
```


One suggestion would be to make the build log a bit more verbose / issue a warning if the generic fallback for Linux is happening (plotting without the GUI still worked!) as it's not currently clear from the log output.