### PR TITLE
Dereference GR_jll.LIBPATH as required in new JLL

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -321,10 +321,10 @@ function init(always=false)
         elseif gr_provider == "BinaryBuilder" && !haskey(ENV, "GKSwstype")
             ENV["GKSwstype"] = "gksqt"
             if os == :Windows
-                ENV["GKS_QT"] = string("set PATH=", GR_jll.LIBPATH, " & ", GR_jll.gksqt_path)
+                ENV["GKS_QT"] = string("set PATH=", GR_jll.LIBPATH[], " & ", GR_jll.gksqt_path)
             else
                 env = (os == :Darwin) ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
-                ENV["GKS_QT"] = string("env $env=", GR_jll.LIBPATH, " ", GR_jll.gksqt_path)
+                ENV["GKS_QT"] = string("env $env=", GR_jll.LIBPATH[], " ", GR_jll.gksqt_path)
             end
         end
         if "GKS_IGNORE_ENCODING" in keys(ENV)


### PR DESCRIPTION
This fixes errors with the new JLL, as seen in https://github.com/jheinen/GR.jl/issues/314#issuecomment-739054665