### PR TITLE
Use constants, but do `touch(pathof(GR))`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,3 @@
-@static if !isdefined(Base, Symbol("@info"))
-    macro info(msg)
-        return :(info($(esc(msg))))
-    end
-end
-
 function get_grdir()
     if "GRDIR" in keys(ENV)
         grdir = ENV["GRDIR"]
@@ -76,6 +70,7 @@ else
 end
 
 if provider == "BinaryBuilder"
+    @info "Creating depsfile. GR provider is BinaryBuilder" provider depsfile
     open(depsfile, "w") do io
         println(io, """
             using GR_jll
@@ -83,6 +78,7 @@ if provider == "BinaryBuilder"
     end
     exit(0)
 elseif provider == "GR"
+    @info "Removing depsfile. GR provider is GR" provider depsfile
     rm(depsfile, force=true)
 else
     @warn("Unrecognized JULIA_GR_PROVIDER \"$provider\".\n",

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -282,13 +282,14 @@ function __init__()
             if attempt_to_rebuild[]
                 attempt_to_rebuild[] = false # Avoid infinite loop
                 println("Your GR installation is incomplete. Rerunning build step for GR package.")
+                ENV["GRDIR"] = ""
                 @eval GR begin
                     import Pkg
                     Pkg.build("GR")
                     # Encourage recompilation of GR
                     touch(pathof(GR))
                 end
-                error("""Rebuilding GR succeeded, but Julia needs to
+                error("""Rebuilding GR succeeded, but Julia needs to be
                 restarted. Start a new Julia session to use GR.""")
             else
                 error("""Your GR installation is incomplete. $grdir is not a

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -287,7 +287,6 @@ function __init__()
                     Pkg.build("GR")
                     # Encourage recompilation of GR
                     touch(pathof(GR))
-                    Pkg.precompile()
                 end
                 error("""Rebuilding GR succeeded, but Julia needs to
                 restarted. Start a new Julia session to use GR.""")


### PR DESCRIPTION
This is a lighter version of #386 that does not use Refs and should be more compatible with Julia 1.5.

The basic idea is that `touch(pathof(GR))` is needed in order to force GR.jl to recompile in the next Julia session.

Unlike #386 this requires the user to restart Julia.