### PR TITLE
Using Libdl.dlsym to dynamically load function pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,22 @@ services:
   - xvfb
 julia:
   - 1.5.4
-  - 1.6.0
+  - 1 # Latest Julia 1.x.y
   - nightly
 notifications:
   email: false
 env:
   - JULIA_DEBUG=GR
 #  - JULIA_DEBUG=GR JULIA_GR_PROVIDER=GR
+jobs:
+  include:
+    - julia: 1
+      os: linux
+      dist: xenial
+      services: xvfb
+      env: JULIA_DEBUG=GR JULIA_GR_PROVIDER=GR
+    - julia: 1
+      os: linux
+      dist: xenial
+      services: xvfb
+      env: JULIA_DEBUG=GR JULIA_GR_PROVIDER=Error

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
   email: false
 env:
   - JULIA_DEBUG=GR
-  - JULIA_DEBUG=GR JULIA_GR_PROVIDER=GR
+#  - JULIA_DEBUG=GR JULIA_GR_PROVIDER=GR

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - xvfb
 julia:
   - 1.5.4
-  - 1 # Latest Julia 1.x.y
+  - 1.6.0
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ julia:
   - nightly
 notifications:
   email: false
+env:
+  - JULIA_DEBUG=GR
+  - JULIA_DEBUG=GR JULIA_GR_PROVIDER=GR

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 GR_jll = "d2c73de3-f751-5644-a686-071e5b155ba9"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -19,7 +20,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.3"
 HTTP = "0.8, 0.9"
 JSON = "0.20, 0.21, 1"
-
+julia = "1.3"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -78,10 +78,16 @@ if provider == "BinaryBuilder"
     end
     exit(0)
 elseif provider == "GR"
-    @info "Removing depsfile. GR provider is GR" provider depsfile
+    @info "Emptying depsfile. GR provider is GR" provider depsfile
     open(depsfile, "w") do io
         println(io, "@debug \"Using GR as a binary provider\"")
     end
+elseif provider == "Error"
+    @info "Intentionally creating an error in depsfile" provider depsfiles
+    open(depsfile, "w") do io
+        println(io, "error(\"This is an intentional error for testing.\")")
+    end
+    exit(0)
 else
     @warn("Unrecognized JULIA_GR_PROVIDER \"$provider\".\n",
           "To fix this, set ENV[\"JULIA_GR_PROVIDER\"] to \"BinaryBuilder\" or \"GR\"\n",

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -73,13 +73,15 @@ if provider == "BinaryBuilder"
     @info "Creating depsfile. GR provider is BinaryBuilder" provider depsfile
     open(depsfile, "w") do io
         println(io, """
-            using GR_jll
+            import GR_jll
         """)
     end
     exit(0)
 elseif provider == "GR"
     @info "Removing depsfile. GR provider is GR" provider depsfile
-    rm(depsfile, force=true)
+    open(depsfile, "w") do io
+        println(io, "@debug \"Using GR as a binary provider\"")
+    end
 else
     @warn("Unrecognized JULIA_GR_PROVIDER \"$provider\".\n",
           "To fix this, set ENV[\"JULIA_GR_PROVIDER\"] to \"BinaryBuilder\" or \"GR\"\n",

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -311,8 +311,6 @@ function __init__()
                 @eval GR begin
                     import Pkg
                     Pkg.build("GR")
-                    # Encourage recompilation of GR
-                    touch(pathof(GR))
                     include(depsfile)
                 end
                 GR.__init__()

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -11,29 +11,38 @@ end
 const None = Union{}
 
 const depsfile = joinpath(dirname(@__DIR__), "deps", "deps.jl")
-if isfile(depsfile)
-    include(depsfile)
-    const gr_provider = "BinaryBuilder"
-else
-    if os == :Windows
-        const libGR = "libGR.dll"
-        const libGR3 = "libGR3.dll"
-        const libGRM = "libGRM.dll"
-    elseif os == :Darwin
-        const libGR = "libGR.dylib"
-        const libGR3 = "libGR3.dylib"
-        const libGRM = "libGRM.dylib"
-    else
-        const libGR = "libGR.so"
-        const libGR3 = "libGR3.so"
-        const libGRM = "libGRM.so"
+try
+    if !isfile(depsfile)
+        touch(depsfile)
     end
-    const gr_provider = "GR"
+    include(depsfile)
+catch err
+    @debug "Could not include depsfile" depsfile err
 end
+
+if os == :Windows
+    const libGR = "libGR.dll"
+    const libGR3 = "libGR3.dll"
+    const libGRM = "libGRM.dll"
+elseif os == :Darwin
+    const libGR = "libGR.dylib"
+    const libGR3 = "libGR3.dylib"
+    const libGRM = "libGRM.dylib"
+else
+    const libGR = "libGR.so"
+    const libGR3 = "libGR3.so"
+    const libGRM = "libGRM.so"
+end
+
 const attempt_to_rebuild = Ref(true)
+const libGR_handle = Ref{Ptr{Nothing}}()
+const libGR3_handle = Ref{Ptr{Nothing}}()
+const libGRM_handle = Ref{Ptr{Nothing}}()
+const gr_provider = Ref("Unknown")
 
 
 import Base64
+import Libdl
 
 export
   init,
@@ -259,13 +268,20 @@ isvscode() = isdefined(Main, :VSCodeServer) && Main.VSCodeServer isa Module && (
 
 function __init__()
     global check_env
+
+    if isdefined(@__MODULE__, :GR_jll)
+        gr_provider[] = "BinaryBuilder"
+    else
+        gr_provider[] = "GR"
+    end
     @debug "GR Binaries:" GR.gr_provider GR.libGR GR.libGR3 GR.libGRM
+
     if "GRDIR" in keys(ENV)
         grdir = ENV["GRDIR"]
         if grdir == ""
             grdir = None
         end
-    elseif gr_provider == "BinaryBuilder"
+    elseif gr_provider[] == "BinaryBuilder"
         grdir = joinpath(dirname(GR_jll.libGR_path), "..")
     else
         grdir = None
@@ -282,21 +298,28 @@ function __init__()
             if attempt_to_rebuild[]
                 attempt_to_rebuild[] = false # Avoid infinite loop
                 println("Your GR installation is incomplete. Rerunning build step for GR package.")
-                ENV["GRDIR"] = ""
+                delete!(ENV, "GRDIR")
                 @eval GR begin
                     import Pkg
                     Pkg.build("GR")
                     # Encourage recompilation of GR
                     touch(pathof(GR))
+                    include(depsfile)
                 end
-                error("""Rebuilding GR succeeded, but Julia needs to be
-                restarted. Start a new Julia session to use GR.""")
-            else
-                error("""Your GR installation is incomplete. $grdir is not a
-                      directory, and GR_jll was not loaded. Rerun build step
-                      for GR package: `import Pkg; Pkg.build(\"GR\")`""")
+                GR.__init__()
+                @info "GR was successfully rebuilt"
+                return
             end
-            return
+            error("""
+            GR was not built correctly and could not be automatically rebuilt.
+            $grdir could not be found.
+            GR_jll could not be loaded.
+
+            Run the following commands:
+
+            ENV["GRDIR"] = ""
+            using Pkg; Pkg.build("GR")
+            """)
         end
     end
     ENV["GRDIR"] = grdir
@@ -310,6 +333,18 @@ function __init__()
         grdir = joinpath(grdir, "bin")
     end
     push!(Base.DL_LOAD_PATH, grdir)
+
+    if isdefined(@__MODULE__, :GR_jll)
+        libGR_handle[] = GR_jll.libGR_handle
+        libGR3_handle[] = GR_jll.libGR3_handle
+        libGRM_handle[] = GR_jll.libGRM_handle
+    else
+        libGR_handle[] = Libdl.dlopen(libGR)
+        libGR3_handle[] = Libdl.dlopen(libGR3)
+        libGRM_handle[] = Libdl.dlopen(libGRM)
+    end
+    @debug "Library handles" libGR_handle[] libGR3_handle[] libGRM_handle[]
+
     check_env = true
     init(true)
 end
@@ -317,7 +352,7 @@ end
 """
 function set_callback()
     callback_c = @cfunction(callback, Cstring, (Cstring, ))
-    ccall((:gr_setcallback, libGR),
+    ccall(Libdl.dlsym(libGR_handle[], :gr_setcallback),
           Nothing,
           (Ptr{Cvoid}, ),
           callback_c)
@@ -340,7 +375,7 @@ function init(always=false)
             file_path = tempname() * ".svg"
             ENV["GKSwstype"] = "svg"
             ENV["GKS_FILEPATH"] = file_path
-        elseif gr_provider == "BinaryBuilder" && !haskey(ENV, "GKSwstype")
+        elseif gr_provider[] == "BinaryBuilder" && !haskey(ENV, "GKSwstype")
             ENV["GKSwstype"] = "gksqt"
             if os == :Windows
                 if !haskey(ENV, "GKS_QT")
@@ -369,21 +404,21 @@ function init(always=false)
 end
 
 function initgr()
-  ccall( (:gr_initgr, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_initgr),
         Nothing,
         ()
         )
 end
 
 function opengks()
-  ccall( (:gr_opengks, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_opengks),
         Nothing,
         ()
         )
 end
 
 function closegks()
-  ccall( (:gr_closegks, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_closegks),
         Nothing,
         ()
         )
@@ -415,7 +450,7 @@ function inqdspsize()
   mheight = Cdouble[0]
   width = Cint[0]
   height = Cint[0]
-  ccall( (:gr_inqdspsize, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqdspsize),
         Nothing,
         (Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
         mwidth, mheight, width, height)
@@ -492,7 +527,7 @@ Available workstation types:
 
 """
 function openws(workstation_id::Int, connection, workstation_type::Int)
-  ccall( (:gr_openws, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_openws),
         Nothing,
         (Int32, Ptr{Cchar}, Int32),
         workstation_id, connection, workstation_type)
@@ -510,7 +545,7 @@ Close the specified workstation.
 
 """
 function closews(workstation_id::Int)
-  ccall( (:gr_closews, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_closews),
         Nothing,
         (Int32, ),
         workstation_id)
@@ -528,7 +563,7 @@ Activate the specified workstation.
 
 """
 function activatews(workstation_id::Int)
-  ccall( (:gr_activatews, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_activatews),
         Nothing,
         (Int32, ),
         workstation_id)
@@ -546,21 +581,21 @@ Deactivate the specified workstation.
 
 """
 function deactivatews(workstation_id::Int)
-  ccall( (:gr_deactivatews, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_deactivatews),
         Nothing,
         (Int32, ),
         workstation_id)
 end
 
 function clearws()
-  ccall( (:gr_clearws, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_clearws),
         Nothing,
         ()
         )
 end
 
 function updatews()
-  ccall( (:gr_updatews, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_updatews),
         Nothing,
         ()
         )
@@ -587,7 +622,7 @@ index.
 function polyline(x, y)
   @assert length(x) == length(y)
   n = length(x)
-  ccall( (:gr_polyline, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_polyline),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y))
@@ -613,7 +648,7 @@ scale factor and color index.
 function polymarker(x, y)
   @assert length(x) == length(y)
   n = length(x)
-  ccall( (:gr_polymarker, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_polymarker),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y))
@@ -677,7 +712,7 @@ height, character up vector, text path and text alignment.
 
 """
 function text(x::Real, y::Real, string)
-  ccall( (:gr_text, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_text),
         Nothing,
         (Float64, Float64, Ptr{UInt8}),
         x, y, latin1(string))
@@ -686,7 +721,7 @@ end
 function inqtext(x, y, string)
   tbx = Cdouble[0, 0, 0, 0]
   tby = Cdouble[0, 0, 0, 0]
-  ccall( (:gr_inqtext, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqtext),
         Nothing,
         (Float64, Float64, Ptr{UInt8}, Ptr{Cdouble}, Ptr{Cdouble}),
         x, y, latin1(string), tbx, tby)
@@ -712,7 +747,7 @@ style, fill area style index and fill area color index.
 function fillarea(x, y)
   @assert length(x) == length(y)
   n = length(x)
-  ccall( (:gr_fillarea, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_fillarea),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y))
@@ -744,7 +779,7 @@ function cellarray(xmin::Real, xmax::Real, ymin::Real, ymax::Real, dimx::Int, di
   if ndims(color) == 2
     color = reshape(color, dimx * dimy)
   end
-  ccall( (:gr_cellarray, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_cellarray),
         Nothing,
         (Float64, Float64, Float64, Float64, Int32, Int32, Int32, Int32, Int32, Int32, Ptr{Int32}),
         xmin, xmax, ymin, ymax, dimx, dimy, 1, 1, dimx, dimy, convert(Vector{Int32}, color))
@@ -776,7 +811,7 @@ function nonuniformcellarray(x, y, dimx::Int, dimy::Int, color)
   end
   nx = dimx == length(x) ? -dimx : dimx
   ny = dimy == length(y) ? -dimy : dimy
-  ccall( (:gr_nonuniformcellarray, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_nonuniformcellarray),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}, Int32, Int32, Int32, Int32, Int32, Int32, Ptr{Int32}),
         convert(Vector{Float64}, x), convert(Vector{Float64}, y), nx, ny, 1, 1, dimx, dimy, convert(Vector{Int32}, color))
@@ -818,7 +853,7 @@ function polarcellarray(xorg::Real, yorg::Real, phimin::Real, phimax::Real, rmin
   if ndims(color) == 2
     color = reshape(color, dimphi * dimr)
   end
-  ccall( (:gr_polarcellarray, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_polarcellarray),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64, Int32, Int32, Int32, Int32, Int32, Int32, Ptr{Int32}),
         xorg, yorg, phimin, phimax, rmin, rmax, dimphi, dimr, 1, 1, dimphi, dimr, convert(Vector{Int32}, color))
@@ -850,7 +885,7 @@ function nonuniformpolarcellarray(x, y, dimx::Int, dimy::Int, color)
   end
   nx = dimx == length(x) ? -dimx : dimx
   ny = dimy == length(y) ? -dimy : dimy
-  ccall( (:gr_nonuniformpolarcellarray, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_nonuniformpolarcellarray),
         Nothing,
         (Float64, Float64, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Int32, Int32, Int32, Int32, Ptr{Int32}),
         0, 0, convert(Vector{Float64}, x), convert(Vector{Float64}, y), nx, ny, 1, 1, dimx, dimy, convert(Vector{Int32}, color))
@@ -879,7 +914,7 @@ function gdp(x, y, primid, datrec)
   @assert length(x) == length(y)
   n = length(x)
   ldr = length(datrec)
-  ccall( (:gr_gdp, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_gdp),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Ptr{Int32}),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y),
@@ -1042,7 +1077,7 @@ The following path codes are recognized:
 function path(x, y, codes)
   @assert length(x) == length(y)
   n = length(x)
-  ccall( (:gr_path, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_path),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Cstring),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y), codes)
@@ -1109,7 +1144,7 @@ If `method` is < -1, then a cubic B-spline is calculated.
 function spline(x, y, m, method)
   @assert length(x) == length(y)
   n = length(x)
-  ccall( (:gr_spline, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_spline),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Int32, Int32),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y), m, method)
@@ -1121,7 +1156,7 @@ function gridit(xd, yd, zd, nx, ny)
   x = Cdouble[1 : nx ;]
   y = Cdouble[1 : ny ;]
   z = Cdouble[1 : nx*ny ;]
-  ccall( (:gr_gridit, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_gridit),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
         nd, convert(Vector{Float64}, xd), convert(Vector{Float64}, yd), convert(Vector{Float64}, zd), nx, ny, x, y, z)
@@ -1168,7 +1203,7 @@ The available line types are:
 
 """
 function setlinetype(style::Int)
-  ccall( (:gr_setlinetype, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setlinetype),
         Nothing,
         (Int32, ),
         style)
@@ -1191,7 +1226,7 @@ The default line width is 1.0, or 1 times the line width generated on the graphi
 
 """
 function setlinewidth(width::Real)
-  ccall( (:gr_setlinewidth, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setlinewidth),
         Nothing,
         (Float64, ),
         width)
@@ -1209,7 +1244,7 @@ Define the color of subsequent polyline output primitives.
 
 """
 function setlinecolorind(color::Int)
-  ccall( (:gr_setlinecolorind, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setlinecolorind),
         Nothing,
         (Int32, ),
         color)
@@ -1307,7 +1342,7 @@ Polymarkers appear centered over their specified coordinates.
 
 """
 function setmarkertype(mtype::Int)
-  ccall( (:gr_setmarkertype, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setmarkertype),
         Nothing,
         (Int32, ),
         mtype)
@@ -1328,7 +1363,7 @@ multiplied by the marker size scale factor.
 
 """
 function setmarkersize(mtype::Real)
-  ccall( (:gr_setmarkersize, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setmarkersize),
         Nothing,
         (Float64, ),
         mtype)
@@ -1346,7 +1381,7 @@ Define the color of subsequent polymarker output primitives.
 
 """
 function setmarkercolorind(color::Int)
-  ccall( (:gr_setmarkercolorind, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setmarkercolorind),
         Nothing,
         (Int32, ),
         color)
@@ -1447,7 +1482,7 @@ precision for GR and produces the highest quality output.
 
 """
 function settextfontprec(font::Int, precision::Int)
-  ccall( (:gr_settextfontprec, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settextfontprec),
         Nothing,
         (Int32, Int32),
         font, precision)
@@ -1469,14 +1504,14 @@ text expansion factor is 1, or one times the normal width-to-height ratio of the
 
 """
 function setcharexpan(factor::Real)
-  ccall( (:gr_setcharexpan, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcharexpan),
         Nothing,
         (Float64, ),
         factor)
 end
 
 function setcharspace(spacing::Real)
-  ccall( (:gr_setcharspace, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcharspace),
         Nothing,
         (Float64, ),
         spacing)
@@ -1497,7 +1532,7 @@ GR uses the default foreground color (black=1) for the default text color index.
 
 """
 function settextcolorind(color::Int)
-  ccall( (:gr_settextcolorind, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settextcolorind),
         Nothing,
         (Int32, ),
         color)
@@ -1519,7 +1554,7 @@ is defined as a percentage of the default window. GR uses the default text heigh
 
 """
 function setcharheight(height::Real)
-  ccall( (:gr_setcharheight, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcharheight),
         Nothing,
         (Float64, ),
         height)
@@ -1527,7 +1562,7 @@ end
 
 function inqcharheight()
   _height = Cdouble[0]
-  ccall( (:gr_inqcharheight, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqcharheight),
         Nothing,
         (Ptr{Cdouble}, ),
         _height)
@@ -1549,7 +1584,7 @@ The text up vector is initially set to (0, 1), horizontal to the baseline.
 
 """
 function setcharup(ux::Real, uy::Real)
-  ccall( (:gr_setcharup, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcharup),
         Nothing,
         (Float64, Float64),
         ux, uy)
@@ -1577,7 +1612,7 @@ Define the current direction in which subsequent text will be drawn.
 
 """
 function settextpath(path::Int)
-  ccall( (:gr_settextpath, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settextpath),
         Nothing,
         (Int32, ),
         path)
@@ -1625,7 +1660,7 @@ alignment and vertical baseline alignment.
 
 """
 function settextalign(horizontal::Int, vertical::Int)
-  ccall( (:gr_settextalign, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settextalign),
         Nothing,
         (Int32, Int32),
         horizontal, vertical)
@@ -1656,7 +1691,7 @@ primitives. The default interior style is HOLLOW.
 
 """
 function setfillintstyle(style::Int)
-  ccall( (:gr_setfillintstyle, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setfillintstyle),
         Nothing,
         (Int32, ),
         style)
@@ -1680,7 +1715,7 @@ for the interior style, the fill style index is unused.
 
 """
 function setfillstyle(index::Int)
-  ccall( (:gr_setfillstyle, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setfillstyle),
         Nothing,
         (Int32, ),
         index)
@@ -1701,7 +1736,7 @@ GR uses the default foreground color (black=1) for the default fill area color i
 
 """
 function setfillcolorind(color::Int)
-  ccall( (:gr_setfillcolorind, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setfillcolorind),
         Nothing,
         (Int32, ),
         color)
@@ -1726,7 +1761,7 @@ an RGB color triplet.
 
 """
 function setcolorrep(index::Int, red::Real, green::Real, blue::Real)
-  ccall( (:gr_setcolorrep, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcolorrep),
         Nothing,
         (Int32, Float64, Float64, Float64),
         index, red, green, blue)
@@ -1769,7 +1804,7 @@ assumes that the axes limits are greater than zero.
 
 """
 function setscale(options::Int)
-  scale = ccall( (:gr_setscale, libGR),
+  scale = ccall( Libdl.dlsym(libGR_handle[], :gr_setscale),
                 Int32,
                 (Int32, ),
                 options)
@@ -1778,7 +1813,7 @@ end
 
 function inqscale()
   _options = Cint[0]
-   ccall( (:gr_inqscale, libGR),
+   ccall( Libdl.dlsym(libGR_handle[], :gr_inqscale),
          Nothing,
          (Ptr{Int32}, ),
          _options)
@@ -1812,7 +1847,7 @@ open and active workstation, in device coordinates. By default, GR uses the rang
 
 """
 function setwindow(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_setwindow, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setwindow),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
@@ -1823,7 +1858,7 @@ function inqwindow()
   _xmax = Cdouble[0]
   _ymin = Cdouble[0]
   _ymax = Cdouble[0]
-  ccall( (:gr_inqwindow, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqwindow),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         _xmin, _xmax, _ymin, _ymax)
@@ -1855,7 +1890,7 @@ workstation, in device coordinates.
 
 """
 function setviewport(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_setviewport, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setviewport),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
@@ -1866,7 +1901,7 @@ function inqviewport()
   _xmax = Cdouble[0]
   _ymin = Cdouble[0]
   _ymax = Cdouble[0]
-  ccall( (:gr_inqviewport, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqviewport),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         _xmin, _xmax, _ymin, _ymax)
@@ -1892,7 +1927,7 @@ device coordinates.
 
 """
 function selntran(transform::Int)
-  ccall( (:gr_selntran, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_selntran),
         Nothing,
         (Int32, ),
         transform)
@@ -1923,7 +1958,7 @@ By default, clipping is on.
 
 """
 function setclip(indicator::Int)
-  ccall( (:gr_setclip, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setclip),
         Nothing,
         (Int32, ),
         indicator)
@@ -1952,7 +1987,7 @@ surface. The aspect ratio of the workstation window is maintained at 1 to 1.
 
 """
 function setwswindow(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_setwswindow, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setwswindow),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
@@ -1981,56 +2016,56 @@ publishing applications.
 
 """
 function setwsviewport(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_setwsviewport, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setwsviewport),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
 end
 
 function createseg(segment::Int)
-  ccall( (:gr_createseg, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_createseg),
         Nothing,
         (Int32, ),
         segment)
 end
 
 function copyseg(segment::Int)
-  ccall( (:gr_copysegws, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_copysegws),
         Nothing,
         (Int32, ),
         segment)
 end
 
 function redrawseg()
-  ccall( (:gr_redrawsegws, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_redrawsegws),
         Nothing,
         ()
         )
 end
 
 function setsegtran(segment::Int, fx::Real, fy::Real, transx::Real, transy::Real, phi::Real, scalex::Real, scaley::Real)
-  ccall( (:gr_setsegtran, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setsegtran),
         Nothing,
         (Int32, Float64, Float64, Float64, Float64, Float64, Float64, Float64),
         segment, fx, fy, transx, transy, phi, scalex, scaley)
 end
 
 function closeseg()
-  ccall( (:gr_closeseg, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_closeseg),
         Nothing,
         ()
         )
 end
 
 function emergencyclosegks()
-  ccall( (:gr_emergencyclosegks, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_emergencyclosegks),
         Nothing,
         ()
         )
 end
 
 function updategks()
-  ccall( (:gr_updategks, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_updategks),
         Nothing,
         ()
         )
@@ -2062,7 +2097,7 @@ between 0° and 90°.
 
 """
 function setspace(zmin::Real, zmax::Real, rotation::Int, tilt::Int)
-  space = ccall( (:gr_setspace, libGR),
+  space = ccall( Libdl.dlsym(libGR_handle[], :gr_setspace),
                 Int32,
                 (Float64, Float64, Int32, Int32),
                 zmin, zmax, rotation, tilt)
@@ -2161,7 +2196,7 @@ function.
 
 """
 function textext(x::Real, y::Real, string)
-  result = ccall( (:gr_textext, libGR),
+  result = ccall( Libdl.dlsym(libGR_handle[], :gr_textext),
                  Int32,
                  (Float64, Float64, Ptr{UInt8}),
                  x, y, latin1(string))
@@ -2172,7 +2207,7 @@ end
 function inqtextext(x::Real, y::Real, string)
   tbx = Cdouble[0, 0, 0, 0]
   tby = Cdouble[0, 0, 0, 0]
-  ccall( (:gr_inqtextext, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqtextext),
         Nothing,
         (Float64, Float64, Ptr{UInt8}, Ptr{Cdouble}, Ptr{Cdouble}),
         x, y, latin1(string), tbx, tby)
@@ -2210,7 +2245,7 @@ the linear or logarithmic transformation established by the `setscale` function.
 
 """
 function axes2d(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real)
-  ccall( (:gr_axes, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_axes),
         Nothing,
         (Float64, Float64, Float64, Float64, Int32, Int32, Float64),
         x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size)
@@ -2261,7 +2296,7 @@ by the `setscale` function.
 function axeslbl(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int, tick_size::Real, fx::Function, fy::Function)
   fx_c = @cfunction($fx, Int32, (Float64, Float64, Cstring, Float64))
   fy_c = @cfunction($fy, Int32, (Float64, Float64, Cstring, Float64))
-  ccall( (:gr_axeslbl, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_axeslbl),
         Nothing,
         (Float64, Float64, Float64, Float64, Int32, Int32, Float64, Ptr{Nothing}, Ptr{Nothing}),
         x_tick, y_tick, x_org, y_org, major_x, major_y, tick_size, fx_c, fy_c)
@@ -2290,14 +2325,14 @@ lines are drawn using black lines and minor grid lines are drawn using gray line
 
 """
 function grid(x_tick::Real, y_tick::Real, x_org::Real, y_org::Real, major_x::Int, major_y::Int)
-  ccall( (:gr_grid, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_grid),
         Nothing,
         (Float64, Float64, Float64, Float64, Int32, Int32),
         x_tick, y_tick, x_org, y_org, major_x, major_y)
 end
 
 function grid3d(x_tick::Real, y_tick::Real, z_tick::Real, x_org::Real, y_org::Real, z_org::Real, major_x::Int, major_y::Int, major_z::Int)
-  ccall( (:gr_grid3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_grid3d),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64, Int32, Int32, Int32),
         x_tick, y_tick, z_tick, x_org, y_org, z_org, major_x, major_y, major_z)
@@ -2323,7 +2358,7 @@ Draw a standard vertical error bar graph.
 function verrorbars(px, py, e1, e2)
   @assert length(px) == length(py) == length(e1) == length(e2)
   n = length(px)
-  ccall( (:gr_verrorbars, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_verrorbars),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, e1), convert(Vector{Float64}, e2))
@@ -2349,7 +2384,7 @@ Draw a standard horizontal error bar graph.
 function herrorbars(px, py, e1, e2)
   @assert length(px) == length(py) == length(e1) == length(e2)
   n = length(px)
-  ccall( (:gr_herrorbars, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_herrorbars),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, e1), convert(Vector{Float64}, e2))
@@ -2378,7 +2413,7 @@ index.
 function polyline3d(px, py, pz)
   @assert length(px) == length(py) == length(pz)
   n = length(px)
-  ccall( (:gr_polyline3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_polyline3d),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, pz))
@@ -2406,14 +2441,14 @@ scale factor and color index.
 function polymarker3d(px, py, pz)
   @assert length(px) == length(py) == length(pz)
   n = length(px)
-  ccall( (:gr_polymarker3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_polymarker3d),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, pz))
 end
 
 function axes3d(x_tick::Real, y_tick::Real, z_tick::Real, x_org::Real, y_org::Real, z_org::Real, major_x::Int, major_y::Int, major_z::Int, tick_size::Real)
-  ccall( (:gr_axes3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_axes3d),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64, Int32, Int32, Int32, Float64),
         x_tick, y_tick, z_tick, x_org, y_org, z_org, major_x, major_y, major_z, tick_size)
@@ -2431,7 +2466,7 @@ Display axis titles just outside of their respective axes.
 
 """
 function titles3d(x_title, y_title, z_title)
-  ccall( (:gr_titles3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_titles3d),
         Nothing,
         (Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}),
         latin1(x_title), latin1(y_title), latin1(z_title))
@@ -2494,7 +2529,7 @@ function surface(px, py, pz, option::Int)
     if ndims(pz) == 2
       pz = reshape(pz, nx * ny)
     end
-    ccall( (:gr_surface, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_surface),
           Nothing,
           (Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32),
           nx, ny, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, pz), option)
@@ -2547,7 +2582,7 @@ function contour(px, py, h, pz, major_h::Int)
     if ndims(pz) == 2
       pz = reshape(pz, nx * ny)
     end
-    ccall( (:gr_contour, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_contour),
           Nothing,
           (Int32, Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32),
           nx, ny, nh, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, h), convert(Vector{Float64}, pz), major_h)
@@ -2597,7 +2632,7 @@ function contourf(px, py, h, pz, major_h::Int)
     if ndims(pz) == 2
       pz = reshape(pz, nx * ny)
     end
-    ccall( (:gr_contourf, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_contourf),
           Nothing,
           (Int32, Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32),
           nx, ny, nh, convert(Vector{Float64}, px), convert(Vector{Float64}, py), convert(Vector{Float64}, h), convert(Vector{Float64}, pz), major_h)
@@ -2609,7 +2644,7 @@ end
 function hexbin(x, y, nbins)
   @assert length(x) == length(y)
   n = length(x)
-  cntmax = ccall( (:gr_hexbin, libGR),
+  cntmax = ccall( Libdl.dlsym(libGR_handle[], :gr_hexbin),
                  Int32,
                  (Int32, Ptr{Float64}, Ptr{Float64}, Int32),
                  n, convert(Vector{Float64}, x), convert(Vector{Float64}, y), nbins)
@@ -2617,14 +2652,14 @@ function hexbin(x, y, nbins)
 end
 
 function setcolormap(index::Int)
-  ccall( (:gr_setcolormap, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcolormap),
         Nothing,
         (Int32, ),
         index)
 end
 
 function colorbar()
-  ccall( (:gr_colorbar, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_colorbar),
         Nothing,
         ()
         )
@@ -2632,7 +2667,7 @@ end
 
 function inqcolor(color::Int)
   rgb = Cint[0]
-  ccall( (:gr_inqcolor, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqcolor),
         Nothing,
         (Int32, Ptr{Int32}),
         color, rgb)
@@ -2640,7 +2675,7 @@ function inqcolor(color::Int)
 end
 
 function inqcolorfromrgb(red::Real, green::Real, blue::Real)
-  color = ccall( (:gr_inqcolorfromrgb, libGR),
+  color = ccall( Libdl.dlsym(libGR_handle[], :gr_inqcolorfromrgb),
                 Int32,
                 (Float64, Float64, Float64),
                 red, green, blue)
@@ -2651,7 +2686,7 @@ function hsvtorgb(h::Real, s::Real, v::Real)
   r = Cdouble[0]
   g = Cdouble[0]
   b = Cdouble[0]
-  ccall( (:gr_hsvtorgb, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_hsvtorgb),
         Nothing,
         (Float64, Float64, Float64, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         h, s, v, r, g, b)
@@ -2659,14 +2694,14 @@ function hsvtorgb(h::Real, s::Real, v::Real)
 end
 
 function tick(amin::Real, amax::Real)
-  return ccall( (:gr_tick, libGR),
+  return ccall( Libdl.dlsym(libGR_handle[], :gr_tick),
                Float64,
                (Float64, Float64),
                amin, amax)
 end
 
 function validaterange(amin::Real, amax::Real)
-  return ccall( (:gr_validaterange, libGR),
+  return ccall( Libdl.dlsym(libGR_handle[], :gr_validaterange),
                Int32,
                (Float64, Float64),
                amin, amax)
@@ -2675,7 +2710,7 @@ end
 function adjustlimits(amin::Real, amax::Real)
   _amin = Cdouble[amin]
   _amax = Cdouble[amax]
-  ccall( (:gr_adjustlimits, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_adjustlimits),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}),
         _amin, _amax)
@@ -2685,7 +2720,7 @@ end
 function adjustrange(amin::Real, amax::Real)
   _amin = Cdouble[amin]
   _amax = Cdouble[amax]
-  ccall( (:gr_adjustrange, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_adjustrange),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}),
         _amin, _amax)
@@ -2727,7 +2762,7 @@ from the given file extension. The following file types are supported:
 
 """
 function beginprint(pathname)
-  ccall( (:gr_beginprint, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_beginprint),
         Nothing,
         (Ptr{Cchar}, ),
         pathname)
@@ -2815,14 +2850,14 @@ The available formats are:
 
 """
 function beginprintext(pathname, mode, fmt, orientation)
-  ccall( (:gr_beginprintext, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_beginprintext),
         Nothing,
         (Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}),
         pathname, mode, fmt, orientation)
 end
 
 function endprint()
-  ccall( (:gr_endprint, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_endprint),
         Nothing,
         ()
         )
@@ -2831,7 +2866,7 @@ end
 function ndctowc(x::Real, y::Real)
   _x = Cdouble[x]
   _y = Cdouble[y]
-  ccall( (:gr_ndctowc, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_ndctowc),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}),
         _x, _y)
@@ -2841,7 +2876,7 @@ end
 function wctondc(x::Real, y::Real)
   _x = Cdouble[x]
   _y = Cdouble[y]
-  ccall( (:gr_wctondc, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_wctondc),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}),
         _x, _y)
@@ -2852,7 +2887,7 @@ function wc3towc(x::Real, y::Real, z::Real)
   _x = Cdouble[x]
   _y = Cdouble[y]
   _z = Cdouble[z]
-  ccall( (:gr_wc3towc, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_wc3towc),
         Nothing,
         (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         _x, _y, _z)
@@ -2877,7 +2912,7 @@ Draw a rectangle using the current line attributes.
 
 """
 function drawrect(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_drawrect, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_drawrect),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
@@ -2901,7 +2936,7 @@ Draw a filled rectangle using the current fill attributes.
 
 """
 function fillrect(xmin::Real, xmax::Real, ymin::Real, ymax::Real)
-  ccall( (:gr_fillrect, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_fillrect),
         Nothing,
         (Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax)
@@ -2933,7 +2968,7 @@ of the given rectangle.
 
 """
 function drawarc(xmin::Real, xmax::Real, ymin::Real, ymax::Real, a1::Real, a2::Real)
-  ccall( (:gr_drawarc, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_drawarc),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax, a1, a2)
@@ -2965,7 +3000,7 @@ of the given rectangle.
 
 """
 function fillarc(xmin::Real, xmax::Real, ymin::Real, ymax::Real, a1::Real, a2::Real)
-  ccall( (:gr_fillarc, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_fillarc),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax, a1, a2)
@@ -3004,7 +3039,7 @@ The following path codes are recognized:
 """
 function drawpath(points, codes, fill::Int)
   len = length(codes)
-  ccall( (:gr_drawpath, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_drawpath),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{UInt8}, Int32),
         len, convert(Vector{Float64}, points), convert(Vector{UInt8}, codes), fill)
@@ -3063,7 +3098,7 @@ The default arrow style is 1.
 
 """
 function setarrowstyle(style::Int)
-  ccall( (:gr_setarrowstyle, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setarrowstyle),
         Nothing,
         (Int32, ),
         style)
@@ -3084,7 +3119,7 @@ The default arrow size is 1.
 
 """
 function setarrowsize(size::Real)
-  ccall( (:gr_setarrowsize, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setarrowsize),
         Nothing,
         (Float64, ),
         size)
@@ -3108,7 +3143,7 @@ function.
 
 """
 function drawarrow(x1::Real, y1::Real, x2::Real, y2::Real)
-  ccall( (:gr_drawarrow, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_drawarrow),
         Nothing,
         (Float64, Float64, Float64, Float64),
         x1, y1, x2, y2)
@@ -3118,7 +3153,7 @@ function readimage(path)
   width = Cint[0]
   height = Cint[0]
   data = Array{Ptr{UInt32}}(undef, 1)
-  ret = ccall( (:gr_readimage, libGR),
+  ret = ccall( Libdl.dlsym(libGR_handle[], :gr_readimage),
               Int32,
               (Ptr{Cchar}, Ptr{Int32}, Ptr{Int32}, Ptr{Ptr{UInt32}}),
               path, width, height, data)
@@ -3167,14 +3202,14 @@ function drawimage(xmin::Real, xmax::Real, ymin::Real, ymax::Real, width::Int, h
   if ndims(data) == 2
     data = reshape(data, width * height)
   end
-  ccall( (:gr_drawimage, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_drawimage),
         Nothing,
         (Float64, Float64, Float64, Float64, Int32, Int32, Ptr{UInt32}, Int32),
         xmin, xmax, ymin, ymax, width, height, convert(Vector{UInt32}, data), model)
 end
 
 function importgraphics(path)
-  return ccall( (:gr_importgraphics, libGR),
+  return ccall( Libdl.dlsym(libGR_handle[], :gr_importgraphics),
                Int32,
                (Ptr{Cchar}, ),
                path)
@@ -3201,7 +3236,7 @@ source cast on the graphics objects.
 
 """
 function setshadow(offsetx::Real, offsety::Real, blur::Real)
-  ccall( (:gr_setshadow, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setshadow),
         Nothing,
         (Float64, Float64, Float64),
         offsetx, offsety, blur)
@@ -3219,7 +3254,7 @@ Set the value of the alpha component associated with GR colors.
 
 """
 function settransparency(alpha::Real)
-  ccall( (:gr_settransparency, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settransparency),
         Nothing,
         (Float64, ),
         alpha)
@@ -3238,7 +3273,7 @@ Change the coordinate transformation according to the given matrix.
 """
 function setcoordxform(mat)
   @assert length(mat) == 6
-  ccall( (:gr_setcoordxform, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setcoordxform),
         Nothing,
         (Ptr{Float64}, ),
         convert(Vector{Float64}, mat))
@@ -3260,21 +3295,21 @@ the `importgraphics` function.
 
 """
 function begingraphics(path)
-  ccall( (:gr_begingraphics, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_begingraphics),
         Nothing,
         (Ptr{Cchar}, ),
         path)
 end
 
 function endgraphics()
-  ccall( (:gr_endgraphics, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_endgraphics),
         Nothing,
         ()
         )
 end
 
 function getgraphics()
-  string = ccall( (:gr_getgraphics, libGR),
+  string = ccall( Libdl.dlsym(libGR_handle[], :gr_getgraphics),
                  Ptr{Cchar},
                  (),
                  )
@@ -3282,7 +3317,7 @@ function getgraphics()
 end
 
 function drawgraphics(string)
-  ret = ccall( (:gr_drawgraphics, libGR),
+  ret = ccall( Libdl.dlsym(libGR_handle[], :gr_drawgraphics),
               Int32,
               (Ptr{Cchar}, ),
               string)
@@ -3307,7 +3342,7 @@ function mathtex(x::Real, y::Real, string)
   if length(string) >= 2 && string[1] == '$' && string[end] == '$'
     string = string[2:end-1]
   end
-  ccall( (:gr_mathtex, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_mathtex),
         Nothing,
         (Float64, Float64, Ptr{Cchar}),
         x, y, string)
@@ -3319,7 +3354,7 @@ function inqmathtex(x, y, string)
   end
   tbx = Cdouble[0, 0, 0, 0]
   tby = Cdouble[0, 0, 0, 0]
-  ccall( (:gr_inqmathtex, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqmathtex),
         Nothing,
         (Float64, Float64, Ptr{UInt8}, Ptr{Cdouble}, Ptr{Cdouble}),
         x, y, string, tbx, tby)
@@ -3698,14 +3733,14 @@ function show()
 end
 
 function setregenflags(flags=0)
-  ccall( (:gr_setregenflags, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setregenflags),
         Nothing,
         (Int32, ),
         flags)
 end
 
 function inqregenflags()
-  flags = ccall( (:gr_inqregenflags, libGR),
+  flags = ccall( Libdl.dlsym(libGR_handle[], :gr_inqregenflags),
                 Int32,
                 ()
                 )
@@ -3713,35 +3748,35 @@ function inqregenflags()
 end
 
 function savestate()
-  ccall( (:gr_savestate, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_savestate),
         Nothing,
         ()
         )
 end
 
 function restorestate()
-  ccall( (:gr_restorestate, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_restorestate),
         Nothing,
         ()
         )
 end
 
 function selectcontext(context::Int)
-  ccall( (:gr_selectcontext, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_selectcontext),
         Nothing,
         (Int32, ),
         context)
 end
 
 function destroycontext(context::Int)
-  ccall( (:gr_destroycontext, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_destroycontext),
         Nothing,
         (Int32, ),
         context)
 end
 
 function uselinespec(linespec)
-  return ccall( (:gr_uselinespec, libGR),
+  return ccall( Libdl.dlsym(libGR_handle[], :gr_uselinespec),
                Int32,
                (Ptr{Cchar}, ),
                linespec)
@@ -3753,7 +3788,7 @@ function delaunay(x, y)
   ntri = Cint[0]
   dim = Cint[3]
   triangles = Array{Ptr{Int32}}(undef, 1)
-  ccall( (:gr_delaunay, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_delaunay),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Int32}, Ptr{Ptr{Int32}}),
         npoints, convert(Vector{Float64}, x), convert(Vector{Float64}, y),
@@ -3789,7 +3824,7 @@ function interp2(X, Y, Z, Xq, Yq, method::Int=0, extrapval=0)
     nxq = length(Xq)
     nyq = length(Yq)
     Zq = Cdouble[1 : nxq * nyq; ]
-    ccall( (:gr_interp2, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_interp2),
           Nothing,
           (Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Cdouble}, Int32, Float64),
           ny, nx, convert(Vector{Float64}, Y), convert(Vector{Float64}, X), convert(Vector{Float64}, Z), nyq, nxq, convert(Vector{Float64}, Yq), convert(Vector{Float64}, Xq), Zq, method, extrapval)
@@ -3820,7 +3855,7 @@ function trisurface(x, y, z)
   ny = length(y)
   nz = length(z)
   n = min(nx, ny, nz)
-  ccall( (:gr_trisurface, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_trisurface),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         n, convert(Vector{Float64}, x), convert(Vector{Float64}, y), convert(Vector{Float64}, z))
@@ -3846,7 +3881,7 @@ Draw a contour plot for the given triangle mesh.
 function tricontour(x, y, z, levels)
   npoints = length(x)
   nlevels = length(levels)
-  ccall( (:gr_tricontour, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_tricontour),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32, Ptr{Float64}),
         npoints, convert(Vector{Float64}, x), convert(Vector{Float64}, y), convert(Vector{Float64}, z), nlevels, convert(Vector{Float64}, levels))
@@ -3869,7 +3904,7 @@ function gradient(x, y, z)
     end
     u = Cdouble[1 : nx*ny ;]
     v = Cdouble[1 : nx*ny ;]
-    ccall( (:gr_gradient, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_gradient),
           Nothing,
           (Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Cdouble}, Ptr{Cdouble}),
           nx, ny, convert(Vector{Float64}, x), convert(Vector{Float64}, y), convert(Vector{Float64}, z), u, v)
@@ -3907,7 +3942,7 @@ function quiver(x, y, u, v, color::Bool=false)
     if ndims(v) == 2
       v = reshape(v, nx * ny)
     end
-    ccall( (:gr_quiver, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_quiver),
           Nothing,
           (Int32, Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Int32),
           nx, ny, convert(Vector{Float64}, x), convert(Vector{Float64}, y), convert(Vector{Float64}, u), convert(Vector{Float64}, v), convert(Int32, color))
@@ -3921,7 +3956,7 @@ function reducepoints(xd, yd, n)
   nd = length(xd)
   x = Cdouble[1 : n ;]
   y = Cdouble[1 : n ;]
-  ccall( (:gr_reducepoints, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_reducepoints),
         Nothing,
         (Int32, Ptr{Float64}, Ptr{Float64}, Int32, Ptr{Cdouble}, Ptr{Cdouble}),
         nd, convert(Vector{Float64}, xd), convert(Vector{Float64}, yd), n, x, y)
@@ -3929,7 +3964,7 @@ function reducepoints(xd, yd, n)
 end
 
 function version()
-  info = ccall( (:gr_version, libGR),
+  info = ccall( Libdl.dlsym(libGR_handle[], :gr_version),
                Cstring,
                ()
                )
@@ -3959,7 +3994,7 @@ end
 
 function openmeta(target=0, device="localhost", port=8002)
     global send_c, recv_c
-    handle = ccall((:grm_open, libGRM),
+    handle = ccall(Libdl.dlsym(libGRM_handle[], :grm_open),
                    Ptr{Nothing},
                    (Int32, Cstring, Int64, Ptr{Cvoid}, Ptr{Cvoid}),
                    target, device, port, send_c, recv_c)
@@ -3967,7 +4002,7 @@ function openmeta(target=0, device="localhost", port=8002)
 end
 
 function sendmeta(handle, string::AbstractString)
-    ccall((:grm_send, libGRM),
+    ccall(Libdl.dlsym(libGRM_handle[], :grm_send),
           Nothing,
           (Ptr{Nothing}, Cstring),
           handle, string)
@@ -3978,7 +4013,7 @@ function sendmetaref(handle, key::AbstractString, fmt::Char, data, len=-1)
         if len == -1
             len = length(data)
         end
-        ccall((:grm_send_ref, libGRM),
+        ccall(Libdl.dlsym(libGRM_handle[], :grm_send_ref),
               Nothing,
               (Ptr{Nothing}, Cstring, Cchar, Cstring, Int32),
               handle, key, fmt, data, len)
@@ -3988,7 +4023,7 @@ function sendmetaref(handle, key::AbstractString, fmt::Char, data, len=-1)
         end
         if typeof(data) <: Array
             if typeof(data[1]) <: String
-                ccall((:grm_send_ref, libGRM),
+                ccall(Libdl.dlsym(libGRM_handle[], :grm_send_ref),
                       Nothing,
                       (Ptr{Nothing}, Cstring, Cchar, Ptr{Ptr{Cchar}}, Int32),
                       handle, key, fmt, data, len)
@@ -3999,7 +4034,7 @@ function sendmetaref(handle, key::AbstractString, fmt::Char, data, len=-1)
         else
             ref = Ref(data)
         end
-        ccall((:grm_send_ref, libGRM),
+        ccall(Libdl.dlsym(libGRM_handle[], :grm_send_ref),
               Nothing,
               (Ptr{Nothing}, Cstring, Cchar, Ptr{Nothing}, Int32),
               handle, key, fmt, ref, len)
@@ -4007,7 +4042,7 @@ function sendmetaref(handle, key::AbstractString, fmt::Char, data, len=-1)
 end
 
 function recvmeta(handle, args=C_NULL)
-    args = ccall((:grm_recv, libGRM),
+    args = ccall(Libdl.dlsym(libGRM_handle[], :grm_recv),
                  Ptr{Nothing},
                  (Ptr{Nothing}, Ptr{Nothing}),
                  handle, args)
@@ -4015,21 +4050,21 @@ function recvmeta(handle, args=C_NULL)
 end
 
 function plotmeta(args)
-    ccall((:grm_plot, libGRM),
+    ccall(Libdl.dlsym(libGRM_handle[], :grm_plot),
           Nothing,
           (Ptr{Nothing}, ),
           args)
 end
 
 function deletemeta(args)
-    ccall((:grm_args_delete, libGRM),
+    ccall(Libdl.dlsym(libGRM_handle[], :grm_args_delete),
           Nothing,
           (Ptr{Nothing}, ),
           args)
 end
 
 function closemeta(handle)
-    ccall((:grm_close, libGRM),
+    ccall(Libdl.dlsym(libGRM_handle[], :grm_close),
           Nothing,
           (Ptr{Nothing}, ),
           handle)
@@ -4039,7 +4074,7 @@ function shadepoints(x, y; dims=[1200, 1200], xform=1)
     @assert length(x) == length(y)
     n = length(x)
     w, h = dims
-    ccall( (:gr_shadepoints, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_shadepoints),
           Nothing,
           (Int32, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Int32),
           n, convert(Vector{Float64}, x), convert(Vector{Float64}, y),
@@ -4050,7 +4085,7 @@ function shadelines(x, y; dims=[1200, 1200], xform=1)
     @assert length(x) == length(y)
     n = length(x)
     w, h = dims
-    ccall( (:gr_shadelines, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_shadelines),
           Nothing,
           (Int32, Ptr{Float64}, Ptr{Float64}, Int32, Int32, Int32),
           n, convert(Vector{Float64}, x), convert(Vector{Float64}, y),
@@ -4066,7 +4101,7 @@ function setcolormapfromrgb(r, g, b; positions=Nothing)
         @assert length(positions) == n
         positions = convert(Vector{Float64}, positions)
     end
-    ccall( (:gr_setcolormapfromrgb, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_setcolormapfromrgb),
           Nothing,
           (Int32, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
           n, convert(Vector{Float64}, r), convert(Vector{Float64}, g),
@@ -4078,7 +4113,7 @@ function panzoom(x, y, zoom)
   xmax = Cdouble[0]
   ymin = Cdouble[0]
   ymax = Cdouble[0]
-  ccall( (:gr_panzoom, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_panzoom),
         Nothing,
         (Float64, Float64, Float64, Float64, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
         x, y, zoom, zoom, xmin, xmax, ymin, ymax)
@@ -4097,7 +4132,7 @@ Define the border width of subsequent path output primitives.
 
 """
 function setborderwidth(width::Real)
-  ccall( (:gr_setborderwidth, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setborderwidth),
         Nothing,
         (Float64, ),
         width)
@@ -4115,28 +4150,28 @@ Define the color of subsequent path output primitives.
 
 """
 function setbordercolorind(color::Int)
-  ccall( (:gr_setbordercolorind, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setbordercolorind),
         Nothing,
         (Int32, ),
         color)
 end
 
 function setprojectiontype(type::Int)
-  ccall( (:gr_setprojectiontype, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setprojectiontype),
         Nothing,
         (Int32, ),
         type)
 end
 
 function setperspectiveprojection(near_plane::Real, far_plane::Real, fov::Real)
-  ccall( (:gr_setperspectiveprojection, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setperspectiveprojection),
         Nothing,
         (Float64, Float64, Float64),
         near_plane, far_plane, fov)
 end
 
 function setorthographicprojection(left::Real, right::Real, bottom::Real, top::Real, near_plane::Real, far_plane::Real)
-  ccall( (:gr_setorthographicprojection, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setorthographicprojection),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64),
         left, right, bottom, top, near_plane, far_plane)
@@ -4145,28 +4180,28 @@ end
 function settransformationparameters(camera_pos_x::Real, camera_pos_y::Real, camera_pos_z::Real,
                                      up_x::Real, up_y::Real, up_z::Real,
                                      focus_point_x::Real, focus_point_y::Real, focus_point_z::Real)
-  ccall( (:gr_settransformationparameters, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_settransformationparameters),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64),
         camera_pos_x, camera_pos_y, camera_pos_z, up_x, up_y, up_z, focus_point_x, focus_point_y, focus_point_z)
 end
 
 function setwindow3d(xmin::Real, xmax::Real, ymin::Real, ymax::Real, zmin::Real, zmax::Real)
-  ccall( (:gr_setwindow3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setwindow3d),
         Nothing,
         (Float64, Float64, Float64, Float64, Float64, Float64),
         xmin, xmax, ymin, ymax, zmin, zmax)
 end
 
 function setspace3d(rot::Real, tilt::Real, fov::Real, dist::Real)
-  ccall( (:gr_setspace3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_setspace3d),
         Nothing,
         (Float64, Float64, Float64, Float64),
         rot, tilt, fov, dist)
 end
 
 function text3d(x::Real, y::Real, z::Real, string, axis::Int)
-  ccall( (:gr_text3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_text3d),
         Nothing,
         (Float64, Float64, Float64, Ptr{UInt8}, Int32),
         x, y, z, latin1(string), axis)
@@ -4175,7 +4210,7 @@ end
 function inqtext3d(x::Real, y::Real, z::Real, string, axis::Int)
   tbx = Cdouble[0 for i in 1:16]
   tby = Cdouble[0 for i in 1:16]
-  ccall( (:gr_inqtext3d, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqtext3d),
         Nothing,
         (Float64, Float64, Float64, Ptr{UInt8}, Int32, Ptr{Cdouble}, Ptr{Cdouble}),
         x, y, z, latin1(string), axis, tbx, tby)
@@ -4184,7 +4219,7 @@ end
 
 function settextencoding(encoding)
     global text_encoding
-    ccall( (:gr_settextencoding, libGR),
+    ccall( Libdl.dlsym(libGR_handle[], :gr_settextencoding),
         Nothing,
         (Int32, ),
         encoding)
@@ -4193,7 +4228,7 @@ end
 
 function inqtextencoding()
   encoding = Cint[0]
-  ccall( (:gr_inqtextencoding, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_inqtextencoding),
         Nothing,
         (Ptr{Cint}, ),
         encoding)
@@ -4202,7 +4237,7 @@ end
 
 function loadfont(name::String)
   font = Cint[0]
-  ccall( (:gr_loadfont, libGR),
+  ccall( Libdl.dlsym(libGR_handle[], :gr_loadfont),
         Cstring,
         (Cstring, Ptr{Cint}),
         name, font)

--- a/src/gr3.jl
+++ b/src/gr3.jl
@@ -38,7 +38,7 @@ const msgs = [ "none", "invalid value", "invalid attribute", "init failed",
 function _check_error()
   line = Cint[0]
   file = Ptr{UInt8}[0]
-  error_code = ccall((:gr3_geterror, GR.libGR3), Int32, (Int32, Ptr{Cint}, Ptr{Ptr{UInt8}}), 1, line, file)
+  error_code = ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_geterror), Int32, (Int32, Ptr{Cint}, Ptr{Ptr{UInt8}}), 1, line, file)
   if (error_code != 0)
     line = line[1]
     file = unsafe_string(file[1])
@@ -53,31 +53,31 @@ function _check_error()
 end
 
 function init(attrib_list)
-  ccall((:gr3_init, GR.libGR3), Int32, (Ptr{Int}, ), attrib_list)
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_init), Int32, (Ptr{Int}, ), attrib_list)
   _check_error()
 end
 export init
 
 function free(pointer)
-  ccall((:gr3_free, GR.libGR3), Nothing, (Ptr{Nothing}, ), pointer)
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_free), Nothing, (Ptr{Nothing}, ), pointer)
   _check_error()
 end
 export free
 
 function terminate()
-  ccall((:gr3_terminate, GR.libGR3), Nothing, ())
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_terminate), Nothing, ())
   _check_error()
 end
 export terminate
 
 function useframebuffer(framebuffer)
-  ccall((:gr3_useframebuffer, GR.libGR3), Nothing, (UInt32, ), framebuffer)
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_useframebuffer), Nothing, (UInt32, ), framebuffer)
   _check_error()
 end
 export useframebuffer
 
 function usecurrentframebuffer()
-  ccall((:gr3_usecurrentframebuffer, GR.libGR3), Nothing, ())
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_usecurrentframebuffer), Nothing, ())
   _check_error()
 end
 export usecurrentframebuffer
@@ -85,7 +85,7 @@ export usecurrentframebuffer
 function getimage(width, height, use_alpha=true)
   bpp = use_alpha ? 4 : 3
   bitmap = zeros(UInt8, width * height * bpp)
-  ccall((:gr3_getimage, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_getimage),
         Int32,
         (Int32, Int32, Int32, Ptr{UInt8}),
         width, height, use_alpha, bitmap)
@@ -95,7 +95,7 @@ end
 export getimage
 
 function save(filename, width, height)
-  ccall((:gr3_export, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_export),
         Int32,
         (Ptr{Cchar}, Int32, Int32),
         filename, width, height)
@@ -113,7 +113,7 @@ end
 export save
 
 function getrenderpathstring()
-  val = ccall((:gr3_getrenderpathstring, GR.libGR3),
+  val = ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_getrenderpathstring),
               Ptr{UInt8}, (), )
   _check_error()
   unsafe_string(val)
@@ -121,7 +121,7 @@ end
 export getrenderpathstring
 
 function drawimage(xmin, xmax, ymin, ymax, pixel_width, pixel_height, window)
-  ccall((:gr3_drawimage, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawimage),
         Int32,
         (Float32, Float32, Float32, Float32, Int32, Int32, Int32),
         xmin, xmax, ymin, ymax, pixel_width, pixel_height, window)
@@ -134,7 +134,7 @@ function createmesh(n, vertices, normals, colors)
   _vertices = [ Float32(x) for x in vertices ]
   _normals = [ Float32(x) for x in normals ]
   _colors = [ Float32(x) for x in colors ]
-  ccall((:gr3_createmesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createmesh),
         Int32,
         (Ptr{Cint}, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         mesh, n, @ArrayToVector(Float32, _vertices), @ArrayToVector(Float32, _normals), @ArrayToVector(Float32, _colors))
@@ -149,7 +149,7 @@ function createindexedmesh(num_vertices, vertices, normals, colors, num_indices,
   _normals = [ Float32(x) for x in normals ]
   _colors = [ Float32(x) for x in colors ]
   _indices = [ Float32(x) for x in indices ]
-  ccall((:gr3_createindexedmesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createindexedmesh),
         Int32,
         (Ptr{Cint}, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Int32, Ptr{Int32}),
         mesh, num_vertices, @ArrayToVector(Float32, _vertices), @ArrayToVector(Float32, _normals), @ArrayToVector(Float32, _colors), num_indices, @ArrayToVector(Float32, _indices))
@@ -164,7 +164,7 @@ function drawmesh(mesh::Int32, n, positions::@triplet(Real), directions::@triple
   _ups = [ Float32(x) for x in ups ]
   _colors = [ Float32(x) for x in colors ]
   _scales = [ Float32(x) for x in scales ]
-  ccall((:gr3_drawmesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawmesh),
         Nothing,
         (Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         mesh, n, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _directions), @ArrayToVector(Float32, _ups), @ArrayToVector(Float32, _colors), @ArrayToVector(Float32, _scales))
@@ -177,7 +177,7 @@ function createheightmapmesh(heightmap, num_columns, num_rows)
     if ndims(heightmap) == 2
       heightmap = reshape(heightmap, num_columns * num_rows)
     end
-    ccall((:gr3_createheightmapmesh, GR.libGR3),
+    ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createheightmapmesh),
           Nothing,
           (Ptr{Float32}, Int32, Int32),
           @ArrayToVector(Float32, heightmap), num_columns, num_rows)
@@ -195,7 +195,7 @@ function drawheightmap(heightmap, num_columns, num_rows, positions, scales)
     end
     _positions = [ Float32(x) for x in positions ]
     _scales = [ Float32(x) for x in scales ]
-    ccall((:gr3_drawheightmap, GR.libGR3),
+    ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawheightmap),
           Nothing,
           (Ptr{Float32}, Int32, Int32, Ptr{Float32}, Ptr{Float32}),
           @ArrayToVector(Float32, heightmap), num_columns, num_rows, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _scales))
@@ -207,19 +207,19 @@ end
 export drawheightmap
 
 function deletemesh(mesh)
-  ccall((:gr3_deletemesh, GR.libGR3), Nothing, (Int32, ), mesh)
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_deletemesh), Nothing, (Int32, ), mesh)
   _check_error()
 end
 export deletemesh
 
 function setquality(quality)
-  ccall((:gr3_setquality, GR.libGR3), Nothing, (Int32, ), quality)
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_setquality), Nothing, (Int32, ), quality)
   _check_error()
 end
 export setquality
 
 function clear()
-  ccall((:gr3_clear, GR.libGR3), Nothing, ())
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_clear), Nothing, ())
   _check_error()
 end
 export clear
@@ -227,7 +227,7 @@ export clear
 function cameralookat(camera_x, camera_y, camera_z,
                       center_x, center_y, center_z,
                       up_x, up_y, up_z)
-  ccall((:gr3_cameralookat, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_cameralookat),
         Nothing,
         (Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32),
         camera_x, camera_y, camera_z, center_x, center_y, center_z, up_x, up_y, up_z)
@@ -236,7 +236,7 @@ end
 export cameralookat
 
 function setcameraprojectionparameters(vertical_field_of_view, zNear, zFar)
-  ccall((:gr3_setcameraprojectionparameters, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_setcameraprojectionparameters),
         Nothing,
         (Float32, Float32, Float32),
         vertical_field_of_view, zNear, zFar)
@@ -245,7 +245,7 @@ end
 export setcameraprojectionparameters
 
 function setlightdirection(x, y, z)
-  ccall((:gr3_setlightdirection, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_setlightdirection),
         Nothing,
         (Float32, Float32, Float32),
         x, y, z)
@@ -259,7 +259,7 @@ function drawcylindermesh(n, positions, directions, colors, radii, lengths)
   _colors = [ Float32(x) for x in colors ]
   _radii = [ Float32(x) for x in radii ]
   _lengths = [ Float32(x) for x in lengths ]
-  ccall((:gr3_drawcylindermesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawcylindermesh),
         Nothing,
         (Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         n, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _directions), @ArrayToVector(Float32, _colors), @ArrayToVector(Float32, _radii), @ArrayToVector(Float32, _lengths))
@@ -273,7 +273,7 @@ function drawconemesh(n, positions, directions, colors, radii, lengths)
   _colors = [ Float32(x) for x in colors ]
   _radii = [ Float32(x) for x in radii ]
   _lengths = [ Float32(x) for x in lengths ]
-  ccall((:gr3_drawconemesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawconemesh),
         Nothing,
         (Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         n, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _directions), @ArrayToVector(Float32, _colors), @ArrayToVector(Float32, _radii), @ArrayToVector(Float32, _lengths))
@@ -285,7 +285,7 @@ function drawspheremesh(n, positions, colors, radii)
   _positions = [ Float32(x) for x in positions ]
   _colors = [ Float32(x) for x in colors ]
   _radii = [ Float32(x) for x in radii ]
-  ccall((:gr3_drawspheremesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawspheremesh),
         Nothing,
         (Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         n, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _colors), @ArrayToVector(Float32, _radii))
@@ -299,7 +299,7 @@ function drawcubemesh(n, positions, directions, ups, colors, scales)
   _ups = [ Float32(x) for x in ups ]
   _colors = [ Float32(x) for x in colors ]
   _scales = [ Float32(x) for x in scales ]
-  ccall((:gr3_drawcubemesh, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_drawcubemesh),
         Nothing,
         (Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}),
         n, @ArrayToVector(Float32, _positions), @ArrayToVector(Float32, _directions), @ArrayToVector(Float32, _ups), @ArrayToVector(Float32, _colors), @ArrayToVector(Float32, _scales))
@@ -308,7 +308,7 @@ end
 export drawcubemesh
 
 function setbackgroundcolor(red, green, blue, alpha)
-  ccall((:gr3_setbackgroundcolor, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_setbackgroundcolor),
         Nothing,
         (Float32, Float32, Float32, Float32),
         red, green, blue, alpha)
@@ -323,7 +323,7 @@ function createisosurfacemesh(grid::Array{UInt16,3}, step::@triplet(Float64), of
   stride_x, stride_y, stride_z = strides(grid)
   step_x, step_y, step_z = [ float(x) for x in step ]
   offset_x, offset_y, offset_z = [ float(x) for x in offset ]
-  err = ccall((:gr3_createisosurfacemesh, GR.libGR3),
+  err = ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createisosurfacemesh),
               Int32,
               (Ptr{Cint}, Ptr{UInt16}, UInt16, UInt32, UInt32, UInt32, UInt32, UInt32, UInt32, Float64, Float64, Float64, Float64, Float64, Float64),
               mesh, @ArrayToVector(UInt16, data), UInt16(isolevel), dim_x, dim_y, dim_z, stride_x, stride_y, stride_z, step_x, step_y, step_z, offset_x, offset_y, offset_z)
@@ -350,7 +350,7 @@ function surface(px, py, pz, option::Int)
     _px = [ Float32(x) for x in px ]
     _py = [ Float32(y) for y in py ]
     _pz = [ Float32(z) for z in pz ]
-    ccall((:gr3_surface, GR.libGR3),
+    ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_surface),
           Nothing,
           (Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Int32),
           nx, ny, @ArrayToVector(Float32, _px), @ArrayToVector(Float32, _py), @ArrayToVector(Float32, _pz), option)
@@ -365,7 +365,7 @@ function volume(data::Array{Float64,3}, algorithm::Int64)
   dmax = Cdouble[-1]
   nx, ny, nz = size(data)
   data = reshape(data, nx * ny * nz)
-  ccall((:gr_volume, GR.libGR3),
+  ccall(Libdl.dlsym(GR.libGR3_handle[], :gr_volume),
         Nothing,
         (Cint, Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}),
         nx, ny, nz, data, algorithm, dmin, dmax)
@@ -410,7 +410,7 @@ function createslicemeshes(grid; x::Union{Real, Nothing}=nothing, y::Union{Real,
     if x != nothing
         x = convert(UInt32, floor(clamp(x, 0, 1) * nx))
         mesh = Cint[0]
-        ccall((:gr3_createxslicemesh, GR.libGR3),
+        ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createxslicemesh),
             Nothing,
             (Ptr{UInt32}, Ptr{UInt16}, UInt32,
             UInt32, UInt32, UInt32,
@@ -431,7 +431,7 @@ function createslicemeshes(grid; x::Union{Real, Nothing}=nothing, y::Union{Real,
     if y != nothing
         y = convert(UInt32, floor(clamp(y, 0, 1) * ny))
         mesh = Cint[0]
-        ccall((:gr3_createyslicemesh, GR.libGR3),
+        ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createyslicemesh),
             Nothing,
             (Ptr{UInt32}, Ptr{UInt16}, UInt32,
             UInt32, UInt32, UInt32,
@@ -452,7 +452,7 @@ function createslicemeshes(grid; x::Union{Real, Nothing}=nothing, y::Union{Real,
     if z != nothing
         z = convert(UInt32, floor(clamp(z, 0, 1) * nz))
         mesh = Cint[0]
-        ccall((:gr3_createzslicemesh, GR.libGR3),
+        ccall(Libdl.dlsym(GR.libGR3_handle[], :gr3_createzslicemesh),
             Nothing,
             (Ptr{UInt32}, Ptr{UInt16}, UInt32,
             UInt32, UInt32, UInt32,

--- a/src/gr3.jl
+++ b/src/gr3.jl
@@ -1,6 +1,7 @@
 module GR3
 
 import GR
+import Libdl
 
 const None = Union{}
 


### PR DESCRIPTION
This version uses `Libdl.dlsym` to load function pointers from library handles set in `__init__`. If `GR_jll` is loaded, then this will use the handles that it loaded.

The library handles are constant references to a `Ptr{Nothing}`. This version should work in Julia 1.5 and Julia 1.6.

An added benefit is that GR can be immediately used after rebuilding. The Julia session does not need to be restarted.

By the third cold execution of GR, things should be relatively fast.
```julia
$ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
[ Info: Precompiling GR [28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71]
Your GR installation is incomplete. Rerunning build step for GR package.
   Building GR → `~/.julia/dev/GR/deps/build.log`
[ Info: GR was successfully rebuilt
  0.316400 seconds (30.14 k allocations: 1.562 MiB)
  0.016258 seconds (27.92 k allocations: 1.458 MiB)
  0.011584 seconds (18.45 k allocations: 1.014 MiB)
 12.061675 seconds (16.11 M allocations: 905.907 MiB, 4.76% gc time)

julia> exit()
$ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
[ Info: Precompiling GR [28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71]
  0.316459 seconds (30.14 k allocations: 1.562 MiB)
  0.017401 seconds (27.92 k allocations: 1.458 MiB)
  0.012289 seconds (18.45 k allocations: 1.014 MiB)
 12.998196 seconds (7.39 M allocations: 424.382 MiB, 1.50% gc time)

julia> exit()
$ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
  0.317188 seconds (30.14 k allocations: 1.562 MiB)
  0.016998 seconds (27.92 k allocations: 1.458 MiB)
  0.116907 seconds (18.45 k allocations: 1.014 MiB, 89.19% gc time)
  5.720824 seconds (6.76 M allocations: 395.635 MiB, 3.76% gc time)

```

For Julia 1.6.0, this goes very quickly:
```julia
$ julia-1.6.0/bin/julia 
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0 (2021-03-24)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
[ Info: Precompiling GR [28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71]
Your GR installation is incomplete. Rerunning build step for GR package.
    Building GR → `~/.julia/dev/GR/deps/build.log`
Precompiling project...
  Progress [========================================>]  2/2
  ? Plots
1 dependency successfully precompiled in 14 seconds (119 already precompiled)
1 dependency failed but may be precompilable after restarting julia
[ Info: GR was successfully rebuilt
  0.315271 seconds (28.65 k allocations: 1.719 MiB, 6.64% compilation time)
  0.044981 seconds (24.23 k allocations: 1.500 MiB, 51.01% gc time, 99.28% compilation time)
  0.012205 seconds (18.39 k allocations: 1.163 MiB, 99.15% compilation time)
 20.081061 seconds (9.05 M allocations: 552.740 MiB, 1.65% gc time, 4.57% compilation time)

julia> exit()
$ julia-1.6.0/bin/julia 
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0 (2021-03-24)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
[ Info: Precompiling GR [28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71]
  0.315480 seconds (28.65 k allocations: 1.719 MiB, 6.84% compilation time)
  0.019071 seconds (24.23 k allocations: 1.500 MiB, 98.97% compilation time)
  0.010915 seconds (18.39 k allocations: 1.163 MiB, 99.04% compilation time)
  3.518684 seconds (1.92 M allocations: 117.392 MiB, 1.31% gc time, 25.71% compilation time)

julia> exit()
$ julia-1.6.0/bin/julia 
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0 (2021-03-24)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> @time begin
           using GR
           x = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
           y = [0.3, 0.5, 0.4, 0.2, 0.6, 0.7]
           @time GR.polyline(x,y)
           @time GR.axes(0.2, 0.2, 0, 0, 1, 1, -0.01)
           @time GR.updatews()
       end
  0.315370 seconds (28.65 k allocations: 1.719 MiB, 7.17% compilation time)
  0.019048 seconds (24.23 k allocations: 1.500 MiB, 98.91% compilation time)
  0.011118 seconds (18.39 k allocations: 1.163 MiB, 98.85% compilation time)
  0.774020 seconds (430.62 k allocations: 30.746 MiB, 2.92% gc time, 7.44% compilation time)
```