### PR TITLE
Fix Jupyter notebooks, add debug statements and inline documentation

### DIFF
--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -24,7 +24,13 @@ const libGR3_ptrs = LibGR3_Ptrs()
 
 const libs_loaded = Ref(false)
 
-function load_libs()
+"""
+    load_libs(always = false)
+
+    Load shared GR libraries from either GR_jll or from GR tarball.
+    always is a boolean flag that is passed through to 
+"""
+function load_libs(always::Bool = false)
     if gr_provider[] == "BinaryBuilder"
         try
             @eval GR import GR_jll
@@ -63,12 +69,12 @@ function load_libs()
     libs_loaded[] = true
 
     check_env[] = true
-    init(true)
+    init(always)
 end
 
 function get_func_ptr(handle::Ref{Ptr{Nothing}}, ptrs::Union{LibGR_Ptrs, LibGRM_Ptrs, LibGR3_Ptrs}, func::Symbol)
     if !libs_loaded[]
-        load_libs()
+        load_libs(true)
     end
     s = getfield(ptrs, func)
     if s == C_NULL
@@ -88,4 +94,4 @@ precompile(get_func_ptr, (Base.RefValue{Ptr{Nothing}},LibGR3_Ptrs, Symbol) )
 precompile(libGR_ptr, (Symbol,))
 precompile(libGRM_ptr, (Symbol,))
 precompile(libGR3_ptr, (Symbol,))
-precompile(load_libs, ())
+precompile(load_libs, (Bool,))


### PR DESCRIPTION
This fixes the issue discussed in https://github.com/jheinen/GR.jl/commit/e2f97d2a9a7086a5913a821615b81c3c4e8e24d7

The primary fix is to pass `always` through `load_libs` back to `init` rather than always calling `init(true)` from `load_libs`.

This allows `check_env[]` to be set to `false` so that environmental variables are not reset upon trying to plot.

Before the fix, but with the the debug statements, I see that plotting attempts to change `GKS_FILEPATH`. You can simulate this by changing Line 419 to `load_libs(true)` rather than `load_lib(always)`.
```julia
juila> ENV["JULIA_DEBUG"] = "GR"

julia> using GR; inline("mov")

┌ Debug: GR Binaries:
│   GR.gr_provider[] = BinaryBuilder
│   GR.libGR = libGR.dll
│   GR.libGR3 = libGR3.dll
│   GR.libGRM = libGRM.dll
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:314
┌ Debug: Library handles
│   libGR_handle[] = Ptr{Nothing} @0x000000006d8e0000
│   libGR3_handle[] = Ptr{Nothing} @0x000000006d6a0000
│   libGRM_handle[] = Ptr{Nothing} @0x000000006d720000
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\funcptrs.jl:67
┌ Debug: Found an embedded environment
│   mime_type[] = svg
│   file_path[] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_a2DAp4FWbR.svg
│   ENV["GKSwstype"] = svg
│   ENV["GKS_FILEPATH"] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_a2DAp4FWbR.svg
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:440
┌ Debug: Default GKS_ENCODING
│   ENV["GKS_ENCODING"] = utf8
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:471
┌ Debug: MIME type change
│   mime_type[] = svg
│   mime = mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3734
┌ Debug: mov
│   file_path[] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_NCLuFXE9gD.mov
│   ENV["GKS_WSTYPE"] = mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3752
┌ Debug: mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3757

julia> for i in 1:25
           plot(randn(10))
       end
┌ Debug: Found an embedded environment
│   mime_type[] = svg
│   file_path[] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_5CB2COJKB4.svg
│   ENV["GKSwstype"] = svg
│   ENV["GKS_FILEPATH"] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_5CB2COJKB4.svg
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:440
┌ Debug: Found GKS_ENCODING in ENV
│   text_encoding[] = 301
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:468
SystemError: opening file "C:\\Users\\KITTIS~1\\AppData\\Local\\Temp\\jl_5CB2COJKB4.svg": No such file or directory
...
```

After the fix, I get the following result.
```julia
juila> ENV["JULIA_DEBUG"] = "GR"

julia> using GR; inline("mov")

┌ Info: Precompiling GR [28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71]
└ @ Base loading.jl:1317
┌ Debug: GR Binaries:
│   GR.gr_provider[] = BinaryBuilder
│   GR.libGR = libGR.dll
│   GR.libGR3 = libGR3.dll
│   GR.libGRM = libGRM.dll
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:314
┌ Debug: Library handles
│   libGR_handle[] = Ptr{Nothing} @0x000000006b7d0000
│   libGR3_handle[] = Ptr{Nothing} @0x000000006b1a0000
│   libGRM_handle[] = Ptr{Nothing} @0x000000006b220000
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\funcptrs.jl:67
┌ Debug: Found an embedded environment
│   mime_type[] = svg
│   file_path[] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_TOJ1uVB9oC.svg
│   ENV["GKSwstype"] = svg
│   ENV["GKS_FILEPATH"] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_TOJ1uVB9oC.svg
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:440
┌ Debug: Default GKS_ENCODING
│   ENV["GKS_ENCODING"] = utf8
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:471
┌ Debug: MIME type change
│   mime_type[] = svg
│   mime = mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3734
┌ Debug: mov
│   file_path[] = C:\Users\KITTIS~1\AppData\Local\Temp\jl_sc7XUxX0YY.mov
│   ENV["GKS_WSTYPE"] = mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3752
┌ Debug: mov
└ @ GR C:\Users\kittisopikulm\.julia\dev\GR\src\GR.jl:3757

julia> for i in 1:25
           plot(randn(10))
       end # No debug output
       
juila> GR.show() # No debug output, correct plot