### PR TITLE
double_buffered is deprecated and breaks on Windows

### DIFF
--- a/examples/gtk_ex.jl
+++ b/examples/gtk_ex.jl
@@ -49,7 +49,6 @@ function value_changed(widget::Gtk.GtkScale)
 end
 
 win = Window("Gtk") |> (bx = Box(:v))
-Gtk.set_gtk_property!(win, :double_buffered, false)
 lb = Label("(-, -)")
 sl = Scale(false, 10, 100, 1)
 Gtk.GAccessor.value(sl, 30)


### PR DESCRIPTION
See: https://docs.gtk.org/gtk3/method.Widget.set_double_buffered.html

