### PR TITLE
Sjk/funcptr1

### DIFF
--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -72,8 +72,8 @@ function load_libs(always::Bool = false)
     init(always)
 end
 
-function get_func_ptr(handle::Ref{Ptr{Nothing}}, ptrs::Union{LibGR_Ptrs, LibGRM_Ptrs, LibGR3_Ptrs}, func::Symbol)
-    if !libs_loaded[]
+function get_func_ptr(handle::Ref{Ptr{Nothing}}, ptrs::Union{LibGR_Ptrs, LibGRM_Ptrs, LibGR3_Ptrs}, func::Symbol, loaded=libs_loaded[])
+    if !loaded
         load_libs(true)
     end
     s = getfield(ptrs, func)
@@ -81,7 +81,7 @@ function get_func_ptr(handle::Ref{Ptr{Nothing}}, ptrs::Union{LibGR_Ptrs, LibGRM_
         s = Libdl.dlsym(handle[], func)
         setfield!(ptrs, func, s)
     end
-    return s
+    return getfield(ptrs,func)
 end
 
 libGR_ptr(func) = get_func_ptr(libGR_handle, libGR_ptrs, func)

--- a/src/jlgr.jl
+++ b/src/jlgr.jl
@@ -631,6 +631,7 @@ function inqtext(x, y, s)
     else
         GR.inqtext(x, y, s)
     end
+    nothing
 end
 
 function text(x, y, s)
@@ -639,6 +640,7 @@ function text(x, y, s)
     else
         GR.text(x, y, s)
     end
+    nothing
 end
 
 function legend_size()
@@ -870,6 +872,7 @@ function usecolorscheme(index)
     else
         println("Invalid color sheme")
     end
+    nothing
 end
 
 """
@@ -1112,6 +1115,7 @@ function send_data(handle, name, data)
     if length(dims) > 1
         GR.sendmetaref(handle, string(name, "_dims"), 'I', to_int(dims))
     end
+    nothing
 end
 
 function send_meta(target)
@@ -1154,6 +1158,7 @@ function send_meta(target)
         GR.sendmetaref(handle[], "", '\0', "", 0);
         #GR.closemeta(handle[])
     end
+    nothing
 end
 
 function send_serialized(target)
@@ -2191,6 +2196,7 @@ function heatmap(D; kv...)
     else
         error("expected 2-D array")
     end
+    nothing
 end
 
 function heatmap(x, y, z; kv...)
@@ -2203,6 +2209,7 @@ function heatmap(x, y, z; kv...)
     else
         error("expected 2-D array")
     end
+    nothing
 end
 
 function polarheatmap(D; kv...)
@@ -2218,6 +2225,7 @@ function polarheatmap(D; kv...)
     else
         error("expected 2-D array")
     end
+    nothing
 end
 
 function polarheatmap(x, y, z; kv...)
@@ -2230,6 +2238,7 @@ function polarheatmap(x, y, z; kv...)
     else
         error("expected 2-D array")
     end
+    nothing
 end
 
 """


### PR DESCRIPTION
This improves the inference of `get_func_ptr`, avoiding a Union split. It also makes some implicit return paths explicit.

Test time on master:
```
 18.638835 seconds (43.80 M allocations: 2.322 GiB, 6.00% gc time, 87.83% compilation time)
```

PR:
```
 15.695953 seconds (26.09 M allocations: 1.408 GiB, 4.87% gc time, 82.81% compilation time)
```
