### PR TITLE
Tweak log "Error importing GR_jll"

### DIFF
--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -39,7 +39,7 @@ function load_libs(always::Bool = false)
             libGRM_handle[] = GR_jll.libGRM_handle
             grdir[] = joinpath(dirname(GR_jll.libGR_path), "..")
         catch err
-            @error "Error importing GR_jll:" err
+            @error "Error importing GR_jll:" exception=(err, catch_backtrace())
             ENV["GRDIR"] = ""
             depsfile_succeeded[] = false
             __init__()


### PR DESCRIPTION
This [convention](https://docs.julialang.org/en/v1/stdlib/Logging/#:~:text=using%20the%20tuple-,exception%3D(ex%2Cbt).,-Examples) will make sure that the error is displayed nicely in the REPL and other IDEs. *Feel free to merge/close/edit without discussion!*