### PR TITLE
`windows` workarounds

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -333,7 +333,7 @@ function init(always::Bool = false)
                 end
                 ENV["GKS_QT"] = string("env $env=", GRPreferences.libpath[], " ", GRPreferences.gksqt[])
             end
-            @debug "BinaryBuilder Setup" ENV["GKSwstype"] ENV["GKS_QT"]
+            @debug "Artifacts setup" ENV["GKSwstype"] ENV["GKS_QT"]
         end
         if "GKS_IGNORE_ENCODING" in keys(ENV)
             text_encoding[] = ENCODING_UTF8

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -324,14 +324,14 @@ function init(always::Bool = false)
         else
             haskey(ENV, "GKSwstype") || get!(ENV, "GKSwstype", "gksqt")
             if !haskey(ENV, "GKS_QT")
-                env = if os === :Windows
+                key = if os === :Windows
                     "PATH"
                 elseif os === :Darwin
                     "DYLD_FALLBACK_LIBRARY_PATH"
                 else
                     "LD_LIBRARY_PATH"
                 end
-                ENV["GKS_QT"] = string("env $env=", GRPreferences.libpath[], " ", GRPreferences.gksqt[])
+                ENV["GKS_QT"] = string("env $key=", GRPreferences.libpath[], " ", GRPreferences.gksqt[])
             end
             @debug "Artifacts setup" ENV["GKSwstype"] ENV["GKS_QT"]
         end

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -324,7 +324,13 @@ function init(always::Bool = false)
         else
             haskey(ENV, "GKSwstype") || get!(ENV, "GKSwstype", "gksqt")
             if !haskey(ENV, "GKS_QT")
-                env = (os == :Darwin) ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
+                env = if os === :Windows
+                    "PATH"
+                elseif os === :Darwin
+                    "DYLD_FALLBACK_LIBRARY_PATH"
+                else
+                    "LD_LIBRARY_PATH"
+                end
                 ENV["GKS_QT"] = string("env $env=", GRPreferences.libpath[], " ", GRPreferences.gksqt[])
             end
             @debug "BinaryBuilder Setup" ENV["GKSwstype"] ENV["GKS_QT"]

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -33,14 +33,15 @@ function load_libs(always::Bool = false)
     libGR_handle[]  = Libdl.dlopen(GRPreferences.libGR[])
     libGR3_handle[] = Libdl.dlopen(GRPreferences.libGR3[])
     libGRM_handle[] = Libdl.dlopen(GRPreferences.libGRM[])
-    @static if Sys.iswindows()
-        ENV["PATH"] = join((GRPreferences.libpath[], get(ENV, "PATH", "")), ";")
-        @debug "Set PATH" ENV["PATH"]
+    env, sep = if os === :Windows
+        "PATH", ";"
+    elseif os === :Darwin
+        "DYLD_FALLBACK_LIBRARY_PATH", ':'
     else
-        env = (os == :Darwin) ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
-        ENV[env] = join((GRPreferences.libpath[], get(ENV, env, "")), ":")
-        @debug "Set library path in $env" ENV[env]
+        "LD_LIBRARY_PATH", ":"
     end
+    ENV[env] = join((GRPreferences.libpath[], get(ENV, env, "")), sep)
+    @debug "Set library search path `$env` to" ENV[env]
     libs_loaded[] = true
     check_env[] = true
     init(always)

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -33,22 +33,15 @@ function load_libs(always::Bool = false)
     libGR_handle[]  = Libdl.dlopen(GRPreferences.libGR[])
     libGR3_handle[] = Libdl.dlopen(GRPreferences.libGR3[])
     libGRM_handle[] = Libdl.dlopen(GRPreferences.libGRM[])
-    lp = GRPreferences.libpath[]
-    env, components, sep = if os === :Windows
-        hard_limit = 4095 - length(lp) - 1
-        prev = if (tmp = get(ENV, "PATH", "")) |> length > hard_limit
-            tmp[1:hard_limit]
-        else
-            tmp
-        end
-        "PATH", (lp, prev), ";"
+    key, sep = if os === :Windows
+        "PATH", ";"
     elseif os === :Darwin
-        "DYLD_FALLBACK_LIBRARY_PATH", nothing, ':'
+        "DYLD_FALLBACK_LIBRARY_PATH", ":"
     else
-        "LD_LIBRARY_PATH", nothing, ":"
+        "LD_LIBRARY_PATH", ":"
     end
-    ENV[env] = join((lp, something(components, get(ENV, env, ""))), sep)
-    @debug "Set library search path `$env` to" ENV[env]
+    ENV[key] = join((GRPreferences.libpath[], get(ENV, key, "")), sep)
+    @debug "Set library search path `$key` to" ENV[key]
     libs_loaded[] = true
     check_env[] = true
     init(always)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
-using Test
-
-using GR
+ENV["JULIA_DEBUG"] = "GR"
 
 using Random
+using Test
+using GR
+
 rng = MersenneTwister(1234)
 
 mutable struct Example


### PR DESCRIPTION
- ~~clamp `PATH` on `windows` (https://github.com/JuliaPlots/Plots.jl/issues/4375#issuecomment-1263336062)~~;
- set `GKS_QT` on windows, with `PATH` changed for `dll`s loading (this seems to have disappeared).

Try to fix https://github.com/jheinen/GR.jl/issues/475.
There was already a similar test in https://github.com/jheinen/GR.jl/blob/ce153a2626413668d0387d6ff62008e2dc3fbf55/test/runtests.jl#L37, so I don't really know what is going on (probably a low level library issue).

I won't be available until tomorrow. @jheinen, you can push in this branch if needed.