### PR TITLE
remove `LD_LIBRARY_PATH` on `linux`, should be handled by `rpath`

### DIFF
--- a/src/GR.jl
+++ b/src/GR.jl
@@ -324,13 +324,12 @@ function init(always::Bool = false)
         else
             haskey(ENV, "GKSwstype") || get!(ENV, "GKSwstype", "gksqt")
             if !haskey(ENV, "GKS_QT")
-                gks_qt = if os === :Windows
+                ENV["GKS_QT"] = if os === :Windows
                     "set PATH=$(GRPreferences.libpath[]) & \"$(GRPreferences.gksqt[])\""
                 else
                     key = os === :Darwin ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
                     "env $key=$(GRPreferences.libpath[]) $(GRPreferences.gksqt[])"
                 end
-                ENV["GKS_QT"] = gks_qt
             end
             @debug "Artifacts setup" ENV["GKSwstype"] ENV["GKS_QT"]
         end

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -27,8 +27,6 @@ end
 import Base64
 import Libdl
 
-const os = Sys.KERNEL === :NT ? :Windows : Sys.KERNEL
-
 export
   init,
   initgr,
@@ -324,10 +322,10 @@ function init(always::Bool = false)
         else
             haskey(ENV, "GKSwstype") || get!(ENV, "GKSwstype", "gksqt")
             if !haskey(ENV, "GKS_QT")
-                ENV["GKS_QT"] = if os === :Windows
+                ENV["GKS_QT"] = if Sys.iswindows()
                     "set PATH=$(GRPreferences.libpath[]) & \"$(GRPreferences.gksqt[])\""
                 else
-                    key = os === :Darwin ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
+                    key = Sys.isapple() ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH"
                     "env $key=$(GRPreferences.libpath[]) $(GRPreferences.gksqt[])"
                 end
             end

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -33,9 +33,13 @@ function load_libs(always::Bool = false)
     libGR_handle[]  = Libdl.dlopen(GRPreferences.libGR[])
     libGR3_handle[] = Libdl.dlopen(GRPreferences.libGR3[])
     libGRM_handle[] = Libdl.dlopen(GRPreferences.libGRM[])
+    lp = GRPreferences.libpath[]
     if os === :Windows
-        ENV["PATH"] = join((GRPreferences.libpath[], get(ENV, "PATH", "")), ';')
+        ENV["PATH"] = join((lp, get(ENV, "PATH", "")), ';')
         @debug "`windows`: set library search path to" ENV["PATH"]
+    elseif os === :Darwin
+        ENV["DYLD_FALLBACK_LIBRARY_PATH"] = join((lp, get(ENV, "DYLD_FALLBACK_LIBRARY_PATH", "")), ':')
+        @debug "`macOS`: set fallback library search path to" ENV["DYLD_FALLBACK_LIBRARY_PATH"]
     end
     libs_loaded[] = true
     check_env[] = true

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -34,10 +34,10 @@ function load_libs(always::Bool = false)
     libGR3_handle[] = Libdl.dlopen(GRPreferences.libGR3[])
     libGRM_handle[] = Libdl.dlopen(GRPreferences.libGRM[])
     lp = GRPreferences.libpath[]
-    if os === :Windows
+    if Sys.iswindows()
         ENV["PATH"] = join((lp, get(ENV, "PATH", "")), ';')
         @debug "`windows`: set library search path to" ENV["PATH"]
-    elseif os === :Darwin
+    elseif Sys.isapple()
         ENV["DYLD_FALLBACK_LIBRARY_PATH"] = join((lp, get(ENV, "DYLD_FALLBACK_LIBRARY_PATH", "")), ':')
         @debug "`macOS`: set fallback library search path to" ENV["DYLD_FALLBACK_LIBRARY_PATH"]
     end

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -33,15 +33,10 @@ function load_libs(always::Bool = false)
     libGR_handle[]  = Libdl.dlopen(GRPreferences.libGR[])
     libGR3_handle[] = Libdl.dlopen(GRPreferences.libGR3[])
     libGRM_handle[] = Libdl.dlopen(GRPreferences.libGRM[])
-    key, sep = if os === :Windows
-        "PATH", ";"
-    elseif os === :Darwin
-        "DYLD_FALLBACK_LIBRARY_PATH", ":"
-    else
-        "LD_LIBRARY_PATH", ":"
+    if os === :Windows
+        ENV["PATH"] = join((GRPreferences.libpath[], get(ENV, "PATH", "")), ';')
+        @debug "`windows`: set library search path to" ENV["PATH"]
     end
-    ENV[key] = join((GRPreferences.libpath[], get(ENV, key, "")), sep)
-    @debug "Set library search path `$key` to" ENV[key]
     libs_loaded[] = true
     check_env[] = true
     init(always)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -6,8 +6,6 @@ module GRPreferences
         @debug "import GR_jll failed" err
     end
 
-    const os = Sys.KERNEL === :NT ? :Windows : Sys.KERNEL
-
     const grdir   = Ref{Union{Nothing,String}}()
     const gksqt   = Ref{Union{Nothing,String}}()
     const libGR   = Ref{Union{Nothing,String}}()
@@ -17,18 +15,16 @@ module GRPreferences
     const libpath = Ref{Union{Nothing,String}}()
 
     lib_path(grdir, lib) =
-        if os === :Windows
+        if Sys.iswindows()
             joinpath(grdir, "bin", lib)
-        elseif os === :Darwin
-            joinpath(grdir, "lib", lib)
         else
             joinpath(grdir, "lib", lib)
         end
 
     gksqt_path(grdir) = 
-        if os === :Windows
+        if Sys.iswindows()
             joinpath(grdir, "bin", "gksqt.exe")
-        elseif os === :Darwin
+        elseif Sys.isapple()
             joinpath(grdir, "Applications", "gksqt.app", "Contents", "MacOS", "gksqt")
         else
             joinpath(grdir, "bin", "gksqt")


### PR DESCRIPTION
Try to fix https://github.com/jheinen/GR.jl/issues/478.

AFAIK there is no `rpath` mechanism on `windows` so we still have to set `PATH`.

`DYLD_FALLBACK_LIBRARY_PATH` on `macOS` seems safe since it does not preempt the library search path as `LD_LIBRARY_PATH` does on `linux` (which is pure evil, only intended to debug stuff, and **should never be used in published software**).

Maybe we should enforce `rpath` compiler flags explicitly in [build_tarballs.jl](https://github.com/JuliaPackaging/Yggdrasil/blob/master/G/GR/build_tarballs.jl) ?
They seem to be set under the hood by `CMake`.

Also modernize `OS` detection (simplifications).