### PR TITLE
Exact pin of `GR_jll`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,8 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
+GR_jll = "=0.69.1"
 HTTP = "0.8, 0.9, 1"
 JSON = "0.20, 0.21, 1"
 Preferences = "1"
-GR_jll = "0.69.1"
 julia = "1.6"


### PR DESCRIPTION
This is too critical to be left floating (unfortunately, we cannot pin the build number: `GR_jll = "=0.69.1+0"` is not allowed by `Pkg`).
A new release of `GR_jll` should trigger a new version of `GR.jl`, **on after being tested** through `CI`.

Sorry if that seems too strict, but the recent breaking changes should never have landed in common users space, and worse, landed in `Plots`.

Xref https://github.com/jheinen/GR.jl/issues/486, https://github.com/jheinen/GR.jl/issues/487.

As @mkitti pointed out, there is a kind of sporadic race condition in volume plots ([`windows` ci](https://github.com/jheinen/GR.jl/actions/runs/3386168821/jobs/5625224044#step:6:388)) causing a segfault:
```
Please submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.
Exception: EXCEPTION_ACCESS_VIOLATION at 0x28fcbed8 -- ray_casting_thread at C:\Users\runneradmin\.julia\artifacts\e40afe22fcfc9fe1caea4af17a4016e7ef36cd66\bin\libGR.dll (unknown line)
in expression starting at none:1
ERROR: LoadError: Package GR errored during testing (exit code: 3221225477)
Stacktrace:
```