### PR TITLE
add downstream `Plots` tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         with:
           prefix: ${{ matrix.prefix }}  # for `xvfb-run`
+      - name: Run downstream Plots tests
+        run: |
+          julia --project=@. --color=yes test/downstream_test.jl
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v3
         with:

--- a/test/downstream_test.jl
+++ b/test/downstream_test.jl
@@ -8,12 +8,13 @@ Plots_jl = joinpath(mkpath(tempname()), "Plots.jl")
 # clone and checkout the latest stable version of Plots
 depot = joinpath(first(DEPOT_PATH), "registries", "General", "P", "Plots", "Versions.toml")
 stable = maximum(VersionNumber.(keys(TOML.parse(read(depot, String)))))
-repo = Pkg.GitTools.ensure_clone(stdout, Plots_jl, "https://github.com/JuliaPlots/Plots.jl")
+# don't use the `https` protocol for `macOS`
+repo = Pkg.GitTools.ensure_clone(stdout, Plots_jl, "http://github.com/JuliaPlots/Plots.jl")
 tag = LibGit2.GitObject(repo, "v$stable")
 hash = string(LibGit2.target(tag))
 LibGit2.checkout!(repo, hash)
 
-# fake the suported GR version for testing
+# fake the supported GR version for testing (for `Pkg.develop`)
 Plots_toml = joinpath(Plots_jl, "Project.toml")
 toml = TOML.parse(read(Plots_toml, String))
 toml["compat"]["GR"] = GR.version()  
@@ -21,7 +22,7 @@ open(Plots_toml, "w") do io
   TOML.print(io, toml)
 end
 Pkg.develop(path=Plots_jl)
-Pkg.status(["Plots", "GR"])
+Pkg.status(["GR", "Plots"])
 
 # test basic plots creation and bitmap or vector exports
 using Plots, Test
@@ -29,9 +30,9 @@ using Plots, Test
 prefix = tempname()
 @time for i ∈ 1:length(Plots._examples)
   i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
-  Plots._examples[i].imports === nothing || continue  # skip examples requiring optional test deps
+  Plots._examples[i].imports ≡ nothing || continue  # skip examples requiring optional test deps
   pl = Plots.test_examples(:gr, i; disp = false)
-  for ext in (".png", ".pdf")
+  for ext in (".png", ".pdf")  # TODO: maybe more ?
     fn = string(prefix, i, ext)
     Plots.savefig(pl, fn)
     @test filesize(fn) > 1_000

--- a/test/downstream_test.jl
+++ b/test/downstream_test.jl
@@ -1,0 +1,39 @@
+using Pkg, GR
+
+LibGit2 = Pkg.GitTools.LibGit2
+TOML = Pkg.TOML
+
+Plots_jl = joinpath(mkpath(tempname()), "Plots.jl")
+
+# clone and checkout the latest stable version of Plots
+depot = joinpath(first(DEPOT_PATH), "registries", "General", "P", "Plots", "Versions.toml")
+stable = maximum(VersionNumber.(keys(TOML.parse(read(depot, String)))))
+repo = Pkg.GitTools.ensure_clone(stdout, Plots_jl, "https://github.com/JuliaPlots/Plots.jl")
+tag = LibGit2.GitObject(repo, "v$stable")
+hash = string(LibGit2.target(tag))
+LibGit2.checkout!(repo, hash)
+
+# fake the suported GR version for testing
+Plots_toml = joinpath(Plots_jl, "Project.toml")
+toml = TOML.parse(read(Plots_toml, String))
+toml["compat"]["GR"] = GR.version()  
+open(Plots_toml, "w") do io
+  TOML.print(io, toml)
+end
+Pkg.develop(path=Plots_jl)
+Pkg.status(["Plots", "GR"])
+
+# test basic plots creation and bitmap or vector exports
+using Plots, Test
+
+prefix = tempname()
+@time for i ∈ 1:length(Plots._examples)
+  i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
+  Plots._examples[i].imports === nothing || continue  # skip examples requiring optional test deps
+  pl = Plots.test_examples(:gr, i; disp = false)
+  for ext in (".png", ".pdf")
+    fn = string(prefix, i, ext)
+    Plots.savefig(pl, fn)
+    @test filesize(fn) > 1_000
+  end
+end


### PR DESCRIPTION
This is a proposal in order to avoid potential `GR` induced `Plots` regressions.

`Plots` and `GR` are tightly linked since `GR` is the default `Plots` backend.
As a result, releasing `GR` changes without testing `Plots` could potentially break `Plots`.

I'm taking the latest example of https://github.com/JuliaPlots/Plots.jl/pull/4507, where `GR@0.70.0` passed `Plots` `ci` whereas `GR@0.70.1` (a patch version, hence declared as non-breaking) broke `Plots` on `windows`, for all `julia` versions, at the precompilation stage.

By testing `Plots` **before** a commit or a PR lands in `GR.jl`, we ensure that potential regressions are caught here, and don't land in `Plots` by inadvertence (since we usually don't pin the `GR` patch version there).

It is worth mentioning that we also run downstream tests in `Plots` (https://github.com/JuliaPlots/Plots.jl/blob/master/.github/workflows/ci.yml#L83-L92), in order to ensure non-breaking behavior for `StatsPlots` or `GraphRecipes`.

The duration of `GR` `ci` tests is increased by around `~3min`, which I believe is acceptable.
Running and saving `Plots` examples increased the duration marginally:
```
 38.767582 seconds (50.10 M allocations: 2.625 GiB, 2.61% gc time, 87.74% compilation time: 5% of which was recompilation)
```

The `ci` failures observed in https://github.com/JuliaPlots/Plots.jl/pull/4507 on `windows` are now reproduced here.