### PR TITLE
Excise `Pkg` and `UUIDs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GR"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 author = ["Josef Heinen (@jheinen)"]
-version = "0.73.3"
+version = "0.73.4"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -13,7 +13,6 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -22,7 +21,6 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]

--- a/src/downloader.jl
+++ b/src/downloader.jl
@@ -5,15 +5,11 @@ GR.GRPreferences.Downloader.download() can be invoked manually.
 """
 module Downloader
 
-using Pkg
-using UUIDs
 using Tar
 using Downloads
 using p7zip_jll
 
 const version = v"0.73.3"
-const GR_UUID = UUID("28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71")
-
 
 """
     get_grdir()
@@ -214,29 +210,7 @@ function apple_install(grdir::String)
     run(
         `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f $app`,
     )
-    try
-        have_qml = @static if VERSION >= v"1.4.0-DEV.265"
-            haskey(
-                Pkg.dependencies(),
-                UUID("2db162a6-7e43-52c3-8d84-290c1c42d82a"),
-            )
-        else
-            haskey(Pkg.API.installed(), "QML")
-        end
-        # Set rpath of gr/lib/qt5plugin.so to that of QML
-        if have_qml
-            @eval import QML
-            qt = QML.qt_prefix_path()
-            path = joinpath(qt, "Frameworks")
-            if isdir(path)
-                qt5plugin = joinpath(grdir, "lib", "qt5plugin.so")
-                run(`install_name_tool -add_rpath $path $qt5plugin`)
-                @info("Using Qt " * splitdir(qt)[end] * " at " * qt)
-            end
-        end
-    catch
-        # Fail silently
-    end
+    nothing
 end
 
 

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -15,7 +15,7 @@ module GRPreferences
         # Ignoring the error causes issues with precompilation.
         rethrow()
     end
-    # include("downloader.jl")
+    include("downloader.jl")
 
     const grdir   = Ref{Union{Nothing,String}}()
     const gksqt   = Ref{Union{Nothing,String}}()

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -15,7 +15,7 @@ module GRPreferences
         # Ignoring the error causes issues with precompilation.
         rethrow()
     end
-    include("downloader.jl")
+    # include("downloader.jl")
 
     const grdir   = Ref{Union{Nothing,String}}()
     const gksqt   = Ref{Union{Nothing,String}}()


### PR DESCRIPTION
Follow up to a conversation on Slack in the `#ttfx` channel. 

In version 1.11, depending on Pkg.jl will no longer be free because it's not in the sysimage, this makes GR.jl slower to load on v1.11 than v1.10. 

The code in GR.jl that uses Pkg is non-functional, since doing a `@eval using QML` when QML.jl isn't in the dep-list will just cause an error. This has probably been failing the entire time this code existed, but wasn't noticed because it's wrapped in a `try/catch` block without even a `@debug` statement. 

This PR alone is not enough to fix the ttfx regression for GR in v1.11, since some of the binary artifacts like the `Xorg` stack also are loading Pkg, but those are apparently being dealt with as well. 