### PR TITLE
use `lts` keyword for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'  # latest LTS (lowest declared compat in `Project.toml`)
+          - '1.6'  # lowest declared compat in `Project.toml`
+          - 'lts'
           - '1'
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch: [x64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
             prefix: xvfb-run  # julia-actions/julia-runtest/blob/master/README.md
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         with:
@@ -41,7 +41,7 @@ jobs:
         run: |
           julia --code-coverage --project=@. --color=yes test/downstream_test.jl
       - uses: julia-actions/julia-processcoverage@latest
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
 


### PR DESCRIPTION
One should run non-regression tests:
- on the lowest declared julia version in `Project.toml`;
- on the current julia lts version;
- on the current julia `1` release branch.

Please run CI in the [GR.jl](https://github.com/jheinen/GR.jl) repo when releasing a new [gr](https://github.com/sciapp/gr) version in order to avoid [breaking](https://github.com/JuliaPlots/Plots.jl/issues/5041) [Plots.jl](https://github.com/JuliaPlots/Plots.jl), this isn't difficult.