### PR TITLE
Add IJulia extension to detect IJulia being loaded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GR"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-author = ["Josef Heinen (@jheinen)"]
 version = "0.73.18"
+author = ["Josef Heinen (@jheinen)"]
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -15,6 +15,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Qt6Wayland_jll = "e99dba38-086e-5de3-a5b1-6e4c66e897c3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -22,7 +23,12 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-Qt6Wayland_jll = "e99dba38-086e-5de3-a5b1-6e4c66e897c3"
+
+[weakdeps]
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+
+[extensions]
+GRIJuliaExt = "IJulia"
 
 [compat]
 Artifacts = "1"
@@ -30,6 +36,7 @@ DelimitedFiles = "1"
 Downloads = "1"
 GR_jll = "=0.73.18"
 HTTP = "0.8, 0.9, 1"
+IJulia = ">=1"
 JSON = "0.20, 0.21, 1"
 Pkg = "1"
 Preferences = "1"

--- a/ext/GRIJuliaExt.jl
+++ b/ext/GRIJuliaExt.jl
@@ -1,0 +1,12 @@
+module GRIJuliaExt
+
+import GR
+import IJulia
+
+function __init__()
+    if @ccall(jl_generating_output()::Cint) == 0
+        GR._ijulia_loaded = true
+    end
+end
+
+end

--- a/src/GR.jl
+++ b/src/GR.jl
@@ -279,7 +279,9 @@ const recv_c = Ref(C_NULL)
 const text_encoding = Ref(ENCODING_UTF8)
 const check_env = Ref(true)
 
-isijulia() = isdefined(Main, :IJulia) && Main.IJulia isa Module && isdefined(Main.IJulia, :clear_output)
+_ijulia_loaded::Bool = false
+
+isijulia() = _ijulia_loaded
 isatom() = isdefined(Main, :Atom) && Main.Atom isa Module && Main.Atom.isconnected() && (isdefined(Main.Atom, :PlotPaneEnabled) ? Main.Atom.PlotPaneEnabled[] : true)
 ispluto() = isdefined(Main, :PlutoRunner) && Main.PlutoRunner isa Module
 isvscode() = isdefined(Main, :VSCodeServer) && Main.VSCodeServer isa Module && (isdefined(Main.VSCodeServer, :PLOT_PANE_ENABLED) ? Main.VSCodeServer.PLOT_PANE_ENABLED[] : true)


### PR DESCRIPTION
This prevents invalidations when used with IJulia and Plots:
```julia
 rebinding Core.Binding(:(Main.IJulia), #undef, Core.BindingPartition(IJulia, 0x0000000000009722, 0xffffffffffffffff, Core.BindingPartition(IJulia, 0x0000000000009721, 0x0000000000009721, Core.BindingPartition(#undef, 0x00000000000075ee, 0
x0000000000009720, #undef, 0x0000000000000009), 0x0000000000000004), 0x0000000000000001), Any[CodeInstance for MethodInstance for Revise.__init__()], 0x00) invalidated:                                                                       
   mt_backedges: 1: signature Main.IJulia triggered MethodInstance for getproperty(::Module, ::Symbol) (0 children)                                                                                                                            
                 2: signature Main.IJulia triggered MethodInstance for GR.isijulia() (462 children)    
```

I didn't do it in this PR, but I think the same approach can be used for `ispluto()`/`isvscode()`/`isatom()`.