### PR TITLE
Fix environment for downstream tests

### DIFF
--- a/GR/test/downstream_test.jl
+++ b/GR/test/downstream_test.jl
@@ -91,6 +91,7 @@ open(Plots_toml, "w") do io
 end
 # Pkg.develop(path=Plots_subdir)
 Pkg.activate(Plots_subdir)
+Pkg.develop(path=pkgdir(GR))
 # Pkg.resolve()
 Pkg.instantiate(; workspace = true)
 # Pkg.status(; workspace = true)


### PR DESCRIPTION
The downstream tests fail, since the GR version that gets added to Plots project file is not yet in the registry, so we have to dev it before resolving the environment.

They should have failed because 0.73.25 and 0.73.26 did indeed brake Plots.jl